### PR TITLE
Add board link

### DIFF
--- a/client/src/views/LogsView.vue
+++ b/client/src/views/LogsView.vue
@@ -386,6 +386,7 @@ html[dir="rtl"] .RTL_Rotation {
 .LogsView__Board_Link code {
   font-size: 0.95rem;
   user-select: all;
+  margin-left: 3px;
 }
 
 @media only screen and (min-width: 48rem) {

--- a/client/src/views/LogsView.vue
+++ b/client/src/views/LogsView.vue
@@ -32,6 +32,10 @@ watch(route, () => {
 });
 watch(configItemsOnly, () => loadPage(1));
 
+const dbbLink = computed(() => {
+  return `${options.baseURL}/${configStore.boardSlug}`
+});
+
 const currentPage = () => {
   return parseInt(
     (route.params.page || boardStore.currentPage || 1).toString(),
@@ -70,8 +74,12 @@ const navigate = (page: number) => {
 };
 
 const downloadLog = () => {
-  window.location.href = `${options.baseURL}/${configStore.boardSlug}/download_log`;
+  window.location.href = `${dbbLink.value}/download_log`;
 };
+
+const boardLink = computed(() => {
+  return `${dbbLink.value}/board`;
+});
 onMounted(() => loadPage(currentPage()));
 </script>
 
@@ -234,6 +242,10 @@ onMounted(() => loadPage(currentPage()));
         icon="download"
         :label="$t('views.logs.download_button')"
       />
+
+      <p class="LogsView__Board_Link">
+        Eller kopier linket: <code>{{ boardLink }}</code>
+      </p>
     </template>
     <template v-slot:help>
       <h3 class="LogsView__Help_Title text-contrast">
@@ -363,6 +375,17 @@ html[dir="rtl"] .RTL_Rotation {
 
 .LogsView__Tooltip {
   cursor: help;
+}
+
+.LogsView__Board_Link {
+  text-align: center;
+  width: 100%;
+  margin: 0;
+}
+
+.LogsView__Board_Link code {
+  font-size: 0.95rem;
+  user-select: all;
 }
 
 @media only screen and (min-width: 48rem) {

--- a/client/src/views/LogsView.vue
+++ b/client/src/views/LogsView.vue
@@ -244,7 +244,7 @@ onMounted(() => loadPage(currentPage()));
       />
 
       <p class="LogsView__Board_Link">
-        Eller kopier linket: <code>{{ boardLink }}</code>
+        {{ $t('views.logs.board_link') }}<code>{{ boardLink }}</code>
       </p>
     </template>
     <template v-slot:help>


### PR DESCRIPTION
Adds a link to the DBB for use with the election verification script.
<img width="872" alt="Screenshot 2024-05-13 at 14 46 50" src="https://github.com/aion-dk/election-verification-site/assets/100700894/f3f62dca-8022-4faa-9697-ec1c987d214e">

Translations are in https://github.com/aion-dk/conference/pull/1310