### PR TITLE
Add attachments download button

### DIFF
--- a/client/src/views/LogsView.vue
+++ b/client/src/views/LogsView.vue
@@ -77,6 +77,10 @@ const downloadLog = () => {
   window.location.href = `${dbbLink.value}/download_log`;
 };
 
+const downloadAttachments = () => {
+  window.location.href = `${dbbLink.value}/download_attachmets`
+}
+
 const boardLink = computed(() => {
   return `${dbbLink.value}/board`;
 });
@@ -242,6 +246,15 @@ onMounted(() => loadPage(currentPage()));
         icon="download"
         :label="$t('views.logs.download_button')"
       />
+      <AVButton
+        @click="downloadAttachments"
+        size="small"
+        type="neutral"
+        class="LogsView__Button_Overrides"
+        iconLeft
+        icon="download"
+        :label="$t('views.logs.download_attachments')"
+      />
 
       <p class="LogsView__Board_Link">
         {{ $t('views.logs.board_link') }}<code>{{ boardLink }}</code>
@@ -368,9 +381,13 @@ html[dir="rtl"] .RTL_Rotation {
 .LogsView__Button_Overrides {
   font-size: 0.75rem !important;
   padding: 0.5rem 0.8rem !important;
-  margin-top: 2rem;
-  margin-bottom: 1rem;
+  margin: 0;
+  margin-top: 1rem;
   align-self: center;
+}
+
+.LogsView__Button_Overrides:first-of-type {
+  margin-top: 2rem;
 }
 
 .LogsView__Tooltip {
@@ -381,6 +398,9 @@ html[dir="rtl"] .RTL_Rotation {
   text-align: center;
   width: 100%;
   margin: 0;
+  margin-top: 1rem;
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
 .LogsView__Board_Link code {
@@ -426,6 +446,11 @@ html[dir="rtl"] .RTL_Rotation {
   .LogsView__Button_Overrides {
     font-size: 0.875rem !important;
     padding: 0.5rem 1.5rem !important;
+    margin: 0;
+    margin-top: 1rem;
+  }
+
+  .LogsView__Button_Overrides:first-of-type {
     margin-top: 4rem;
   }
 }


### PR DESCRIPTION
This adds a download button to download all the DBB attachments. This depends on https://github.com/aion-dk/dbb/pull/495/files and https://github.com/aion-dk/conference/pull/1321. 

<img width="909" alt="Screenshot 2024-05-17 at 14 13 49" src="https://github.com/aion-dk/election-verification-site/assets/100700894/0d9370dc-c7e5-43f1-bd5e-4c6487299adb">
<img width="422" alt="Screenshot 2024-05-17 at 14 13 57" src="https://github.com/aion-dk/election-verification-site/assets/100700894/8cc5ca21-e0a6-4cb1-b4e2-0ecdc7527c3b">
