### PR TITLE
circleci: disable docker_layer_caching to avoid BuildKit parent snaps…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
   vm-linux-ubuntu:
     machine:
       image: ubuntu-2204:current
-      docker_layer_caching: true
+      docker_layer_caching: false
   vm-linux-ubuntu-nocache:
     machine:
       image: ubuntu-2204:current

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -10,9 +10,10 @@ COPY . .
 
 RUN yarn build
 
-FROM builder AS development
+FROM mcr.microsoft.com/playwright:v1.58.2-noble AS development
 
-RUN npx playwright install --with-deps
+WORKDIR /usr/src/app
+COPY --from=builder /usr/src/app .
 
 FROM nginx:1.29-alpine AS production
 # Copy the built app only (Vite default output directory is "dist")


### PR DESCRIPTION
Same fix than https://github.com/aion-dk/trustee-service/pull/119/changes/4e4c2e75ff3790add7e1d8791b41a11b415e4cd7