### PR TITLE
Add a11y test using axe core

### DIFF
--- a/client/e2e/accessibility.spec.ts
+++ b/client/e2e/accessibility.spec.ts
@@ -1,5 +1,5 @@
 import { test, Page } from "@playwright/test";
-import analyzeAccesibility from "./accessibility";
+import analyzeAccessibility from "./accessibility";
 import {
   latestConfig,
   status,
@@ -48,7 +48,7 @@ test.describe("Welcome page", () => {
   test("initial render has no WCAG violations", async ({ page }) => {
     await setupCommonMocks(page);
     await page.goto(BASE_PATH);
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 
   test("mobile hamburger menu open has no WCAG violations", async ({
@@ -59,7 +59,7 @@ test.describe("Welcome page", () => {
     await setupCommonMocks(page);
     await page.goto(BASE_PATH);
     await page.locator(".Header__Hamburger_Btn").click();
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 });
 
@@ -67,7 +67,7 @@ test.describe("Ballot Verification page", () => {
   test("initial render has no WCAG violations", async ({ page }) => {
     await setupCommonMocks(page);
     await page.goto(`${BASE_PATH}/verify`);
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 
   test("after submitting valid code has no WCAG violations", async ({
@@ -89,7 +89,7 @@ test.describe("Ballot Verification page", () => {
     await page.goto(`${BASE_PATH}/verify`);
     await page.getByPlaceholder("Testing code").fill("5ksv8Ee");
     await page.getByRole("button", { name: "Start the Test" }).click();
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 
   test("invalid code error state has no WCAG violations", async ({ page }) => {
@@ -109,7 +109,7 @@ test.describe("Ballot Verification page", () => {
     await page.goto(`${BASE_PATH}/verify`);
     await page.locator("#verification-code").fill("invalid-code");
     await page.getByRole("button", { name: "Start the Test" }).click();
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 });
 
@@ -117,7 +117,7 @@ test.describe("Ballot Tracking page", () => {
   test("initial render has no WCAG violations", async ({ page }) => {
     await setupCommonMocks(page);
     await page.goto(`${BASE_PATH}/track`);
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 
   test("after tracking a valid ballot has no WCAG violations", async ({
@@ -136,7 +136,7 @@ test.describe("Ballot Tracking page", () => {
     await page.goto(`${BASE_PATH}/track`);
     await page.locator("#tracking-code").fill("5ksv8Ee");
     await page.getByRole("button", { name: "Track my ballot" }).click();
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 
   test("after expanding activity section has no WCAG violations", async ({
@@ -156,7 +156,7 @@ test.describe("Ballot Tracking page", () => {
     await page.locator("#tracking-code").fill("5ksv8Ee");
     await page.getByRole("button", { name: "Track my ballot" }).click();
     await page.locator(".ExpandableSection__Expander").first().click();
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 
   test("after canceling tracking has no WCAG violations", async ({ page }) => {
@@ -174,7 +174,7 @@ test.describe("Ballot Tracking page", () => {
     await page.locator("#tracking-code").fill("5ksv8Ee");
     await page.getByRole("button", { name: "Track my ballot" }).click();
     await page.getByRole("button", { name: "Cancel tracking 5ksv8Ee" }).click();
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 
   test("non-existing ballot error state has no WCAG violations", async ({
@@ -193,7 +193,7 @@ test.describe("Ballot Tracking page", () => {
     await page.goto(`${BASE_PATH}/track`);
     await page.locator("#tracking-code").fill("abcdef");
     await page.getByRole("button", { name: "Track my ballot" }).click();
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 });
 
@@ -214,7 +214,7 @@ test.describe("Election Activity Logs page", () => {
       await page.locator(".Header__Hamburger_Btn").click();
     }
     await page.getByRole("link", { name: "Election Activity Log" }).click();
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 
   test("with expanded board items has no WCAG violations", async ({
@@ -238,7 +238,7 @@ test.describe("Election Activity Logs page", () => {
     await page.getByRole("link", { name: "Election Activity Log" }).click();
     await page.getByText("Rejected affidavit").click();
     await page.getByText("Accepted affidavit").click();
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 
   test("after paginating to page 2 has no WCAG violations", async ({
@@ -268,7 +268,7 @@ test.describe("Election Activity Logs page", () => {
     }
     await page.getByRole("link", { name: "Election Activity Log" }).click();
     await page.getByRole("button", { name: "Next page" }).click();
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 });
 
@@ -280,7 +280,7 @@ test.describe("Help page", () => {
       await page.locator(".Header__Hamburger_Btn").click();
     }
     await page.getByRole("link", { name: "FAQ" }).click();
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 });
 
@@ -295,6 +295,6 @@ test.describe("Locale switching", () => {
       await page.locator(".Header__Hamburger_Btn").click();
     }
     await page.locator(".Header__Locales select").selectOption("es");
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   });
 });

--- a/client/e2e/accessibility.spec.ts
+++ b/client/e2e/accessibility.spec.ts
@@ -1,0 +1,299 @@
+import { test, Page } from "@playwright/test";
+import analyzeAccesibility from "./accessibility";
+import {
+  latestConfig,
+  status,
+  foundBallotStatus,
+  boardItemsPage1,
+  boardItemsPage2,
+} from "./mocks";
+
+const BASE_PATH = "/en/organisation_slug/election_slug";
+
+async function setupCommonMocks(page: Page, extraMocks?: (url: string) => { status: number; contentType: string; body: string } | null) {
+  await page.route("**/*", async (route) => {
+    const url = route.request().url();
+
+    if (url.indexOf("board_slug/configuration/latest_config") > 0) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(latestConfig),
+      });
+    }
+
+    if (url.indexOf("/status") > 0) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(status),
+      });
+    }
+
+    if (extraMocks) {
+      const extra = extraMocks(url);
+      if (extra) return route.fulfill(extra);
+    }
+
+    return route.continue();
+  });
+}
+
+test.describe("Welcome page", () => {
+  test("initial render has no WCAG violations", async ({ page }) => {
+    await setupCommonMocks(page);
+    await page.goto(BASE_PATH);
+    await analyzeAccesibility(page);
+  });
+
+  test("mobile hamburger menu open has no WCAG violations", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!isMobile, "Mobile-only test");
+    await setupCommonMocks(page);
+    await page.goto(BASE_PATH);
+    await page.locator(".Header__Hamburger_Btn").click();
+    await analyzeAccesibility(page);
+  });
+});
+
+test.describe("Ballot Verification page", () => {
+  test("initial render has no WCAG violations", async ({ page }) => {
+    await setupCommonMocks(page);
+    await page.goto(`${BASE_PATH}/verify`);
+    await analyzeAccesibility(page);
+  });
+
+  test("after submitting valid code has no WCAG violations", async ({
+    page,
+  }) => {
+    await setupCommonMocks(page, (url) => {
+      if (
+        url.indexOf(
+          "organisation_slug/election_slug/verification/vote_track"
+        ) > 0
+      ) {
+        return {
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ status: "found" }),
+        };
+      }
+      return null;
+    });
+    await page.goto(`${BASE_PATH}/verify`);
+    await page.getByPlaceholder("Testing code").fill("5ksv8Ee");
+    await page.getByRole("button", { name: "Start the Test" }).click();
+    await analyzeAccesibility(page);
+  });
+
+  test("invalid code error state has no WCAG violations", async ({ page }) => {
+    await setupCommonMocks(page, (url) => {
+      if (
+        url.indexOf(
+          "organisation_slug/election_slug/verification/vote_track"
+        ) > 0
+      ) {
+        return {
+          status: 404,
+          contentType: "application/json",
+          body: "",
+        };
+      }
+      return null;
+    });
+    await page.goto(`${BASE_PATH}/verify`);
+    await page.locator("#verification-code").fill("invalid-code");
+    await page.getByRole("button", { name: "Start the Test" }).click();
+    await analyzeAccesibility(page);
+  });
+});
+
+test.describe("Ballot Tracking page", () => {
+  test("initial render has no WCAG violations", async ({ page }) => {
+    await setupCommonMocks(page);
+    await page.goto(`${BASE_PATH}/track`);
+    await analyzeAccesibility(page);
+  });
+
+  test("after tracking a valid ballot has no WCAG violations", async ({
+    page,
+  }) => {
+    await setupCommonMocks(page, (url) => {
+      if (url.indexOf("board_slug/ballot_status") > 0) {
+        return {
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(foundBallotStatus),
+        };
+      }
+      return null;
+    });
+    await page.goto(`${BASE_PATH}/track`);
+    await page.locator("#tracking-code").fill("5ksv8Ee");
+    await page.getByRole("button", { name: "Track my ballot" }).click();
+    await analyzeAccesibility(page);
+  });
+
+  test("after expanding activity section has no WCAG violations", async ({
+    page,
+  }) => {
+    await setupCommonMocks(page, (url) => {
+      if (url.indexOf("board_slug/ballot_status") > 0) {
+        return {
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(foundBallotStatus),
+        };
+      }
+      return null;
+    });
+    await page.goto(`${BASE_PATH}/track`);
+    await page.locator("#tracking-code").fill("5ksv8Ee");
+    await page.getByRole("button", { name: "Track my ballot" }).click();
+    await page.locator(".ExpandableSection__Expander").first().click();
+    await analyzeAccesibility(page);
+  });
+
+  test("after canceling tracking has no WCAG violations", async ({ page }) => {
+    await setupCommonMocks(page, (url) => {
+      if (url.indexOf("board_slug/ballot_status") > 0) {
+        return {
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(foundBallotStatus),
+        };
+      }
+      return null;
+    });
+    await page.goto(`${BASE_PATH}/track`);
+    await page.locator("#tracking-code").fill("5ksv8Ee");
+    await page.getByRole("button", { name: "Track my ballot" }).click();
+    await page
+      .getByRole("button", { name: "Cancel tracking 5ksv8Ee" })
+      .click();
+    await analyzeAccesibility(page);
+  });
+
+  test("non-existing ballot error state has no WCAG violations", async ({
+    page,
+  }) => {
+    await setupCommonMocks(page, (url) => {
+      if (url.indexOf("board_slug/ballot_status") > 0) {
+        return {
+          status: 404,
+          contentType: "application/json",
+          body: JSON.stringify({}),
+        };
+      }
+      return null;
+    });
+    await page.goto(`${BASE_PATH}/track`);
+    await page.locator("#tracking-code").fill("abcdef");
+    await page.getByRole("button", { name: "Track my ballot" }).click();
+    await analyzeAccesibility(page);
+  });
+});
+
+test.describe("Election Activity Logs page", () => {
+  test("initial render has no WCAG violations", async ({ page, isMobile }) => {
+    await setupCommonMocks(page, (url) => {
+      if (url.indexOf("board_slug/board?page=1") > 0) {
+        return {
+          status: 200,
+          contentType: "application/octet-stream",
+          body: JSON.stringify(boardItemsPage1),
+        };
+      }
+      return null;
+    });
+    await page.goto(BASE_PATH);
+    if (isMobile) {
+      await page.locator(".Header__Hamburger_Btn").click();
+    }
+    await page.getByRole("link", { name: "Election Activity Log" }).click();
+    await analyzeAccesibility(page);
+  });
+
+  test("with expanded board items has no WCAG violations", async ({
+    page,
+    isMobile,
+  }) => {
+    await setupCommonMocks(page, (url) => {
+      if (url.indexOf("board_slug/board?page=1") > 0) {
+        return {
+          status: 200,
+          contentType: "application/octet-stream",
+          body: JSON.stringify(boardItemsPage1),
+        };
+      }
+      return null;
+    });
+    await page.goto(BASE_PATH);
+    if (isMobile) {
+      await page.locator(".Header__Hamburger_Btn").click();
+    }
+    await page.getByRole("link", { name: "Election Activity Log" }).click();
+    await page.getByText("Rejected affidavit").click();
+    await page.getByText("Accepted affidavit").click();
+    await analyzeAccesibility(page);
+  });
+
+  test("after paginating to page 2 has no WCAG violations", async ({
+    page,
+    isMobile,
+  }) => {
+    await setupCommonMocks(page, (url) => {
+      if (url.indexOf("board_slug/board?page=1") > 0) {
+        return {
+          status: 200,
+          contentType: "application/octet-stream",
+          body: JSON.stringify(boardItemsPage1),
+        };
+      }
+      if (url.indexOf("board_slug/board?page=2") > 0) {
+        return {
+          status: 200,
+          contentType: "application/octet-stream",
+          body: JSON.stringify(boardItemsPage2),
+        };
+      }
+      return null;
+    });
+    await page.goto(BASE_PATH);
+    if (isMobile) {
+      await page.locator(".Header__Hamburger_Btn").click();
+    }
+    await page.getByRole("link", { name: "Election Activity Log" }).click();
+    await page.getByRole("button", { name: "Next page" }).click();
+    await analyzeAccesibility(page);
+  });
+});
+
+test.describe("Help page", () => {
+  test("initial render has no WCAG violations", async ({ page, isMobile }) => {
+    await setupCommonMocks(page);
+    await page.goto(BASE_PATH);
+    if (isMobile) {
+      await page.locator(".Header__Hamburger_Btn").click();
+    }
+    await page.getByRole("link", { name: "FAQ" }).click();
+    await analyzeAccesibility(page);
+  });
+});
+
+test.describe("Locale switching", () => {
+  test("after switching locale has no WCAG violations", async ({
+    page,
+    isMobile,
+  }) => {
+    await setupCommonMocks(page);
+    await page.goto(BASE_PATH);
+    if (isMobile) {
+      await page.locator(".Header__Hamburger_Btn").click();
+    }
+    await page.locator(".Header__Locales select").selectOption("es");
+    await analyzeAccesibility(page);
+  });
+});

--- a/client/e2e/accessibility.spec.ts
+++ b/client/e2e/accessibility.spec.ts
@@ -10,7 +10,12 @@ import {
 
 const BASE_PATH = "/en/organisation_slug/election_slug";
 
-async function setupCommonMocks(page: Page, extraMocks?: (url: string) => { status: number; contentType: string; body: string } | null) {
+async function setupCommonMocks(
+  page: Page,
+  extraMocks?: (
+    url: string,
+  ) => { status: number; contentType: string; body: string } | null,
+) {
   await page.route("**/*", async (route) => {
     const url = route.request().url();
 
@@ -70,9 +75,8 @@ test.describe("Ballot Verification page", () => {
   }) => {
     await setupCommonMocks(page, (url) => {
       if (
-        url.indexOf(
-          "organisation_slug/election_slug/verification/vote_track"
-        ) > 0
+        url.indexOf("organisation_slug/election_slug/verification/vote_track") >
+        0
       ) {
         return {
           status: 200,
@@ -91,9 +95,8 @@ test.describe("Ballot Verification page", () => {
   test("invalid code error state has no WCAG violations", async ({ page }) => {
     await setupCommonMocks(page, (url) => {
       if (
-        url.indexOf(
-          "organisation_slug/election_slug/verification/vote_track"
-        ) > 0
+        url.indexOf("organisation_slug/election_slug/verification/vote_track") >
+        0
       ) {
         return {
           status: 404,
@@ -170,9 +173,7 @@ test.describe("Ballot Tracking page", () => {
     await page.goto(`${BASE_PATH}/track`);
     await page.locator("#tracking-code").fill("5ksv8Ee");
     await page.getByRole("button", { name: "Track my ballot" }).click();
-    await page
-      .getByRole("button", { name: "Cancel tracking 5ksv8Ee" })
-      .click();
+    await page.getByRole("button", { name: "Cancel tracking 5ksv8Ee" }).click();
     await analyzeAccesibility(page);
   });
 

--- a/client/e2e/accessibility.ts
+++ b/client/e2e/accessibility.ts
@@ -3,8 +3,8 @@ import { expect } from "@playwright/test";
 
 async function analyzeAccesibility(page: any) {
   const accessibilityScanResults = await new AxeBuilder({ page })
-    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
-    .disableRules(["nested-interactive"])
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "best-practice"])
+    .disableRules(["nested-interactive", "scrollable-region-focusable"])
     .analyze();
 
   accessibilityScanResults.violations.forEach((v) =>
@@ -18,7 +18,7 @@ async function analyzeAccesibility(page: any) {
     }),
   );
 
-  await expect(accessibilityScanResults.violations.length).toEqual(0);
+  expect(accessibilityScanResults.violations.length).toEqual(0);
 }
 
 export default analyzeAccesibility;

--- a/client/e2e/accessibility.ts
+++ b/client/e2e/accessibility.ts
@@ -1,10 +1,10 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect } from "@playwright/test";
 
-async function analyzeAccesibility(page: any) {
+async function analyzeAccessibility(page: any) {
   const accessibilityScanResults = await new AxeBuilder({ page })
     .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "best-practice"])
-    .disableRules(["nested-interactive", "scrollable-region-focusable"])
+    .disableRules(["nested-interactive"])
     .analyze();
 
   accessibilityScanResults.violations.forEach((v) =>
@@ -21,4 +21,4 @@ async function analyzeAccesibility(page: any) {
   expect(accessibilityScanResults.violations.length).toEqual(0);
 }
 
-export default analyzeAccesibility;
+export default analyzeAccessibility;

--- a/client/e2e/locales.spec.ts
+++ b/client/e2e/locales.spec.ts
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test";
 import { latestConfig, status } from "./mocks";
-import analyzeAccesibility from "./accessibility";
+import analyzeAccessibility from "./accessibility";
 
 test("changing locale", async ({ page, isMobile }) => {
   // Mock Network calls
@@ -30,14 +30,14 @@ test("changing locale", async ({ page, isMobile }) => {
 
   await page.goto("/en/organisation_slug/election_slug");
 
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
 
   if (isMobile) {
     await page.locator(".Header__Hamburger_Btn").click();
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   }
   await page.locator(".Header__Locales select").selectOption("es");
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
   await page.getByRole("link", { name: "Testeo de Boleta" }).click();
   if (isMobile) {
     await page.locator(".Header__Hamburger_Btn").click();

--- a/client/e2e/logs.spec.ts
+++ b/client/e2e/logs.spec.ts
@@ -1,5 +1,5 @@
 import { test } from "@playwright/test";
-import analyzeAccesibility from "./accessibility";
+import analyzeAccessibility from "./accessibility";
 import {
   latestConfig,
   boardItemsPage1,
@@ -43,13 +43,13 @@ test("downloading logs", async ({ page, isMobile }) => {
   });
 
   await page.goto("/en/organisation_slug/election_slug");
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
   if (isMobile) {
     await page.locator(".Header__Hamburger_Btn").click();
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   }
   await page.getByRole("link", { name: "Election Activity Log" }).click();
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
 
   if (!isMobile) {
     // The waitForEvent("download") method does not work in safari mobile so I'll skip it for now in mobile.
@@ -108,25 +108,25 @@ test("traversing board items", async ({ page, isMobile }) => {
   });
 
   await page.goto("/en/organisation_slug/election_slug");
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
   if (isMobile) {
     await page.locator(".Header__Hamburger_Btn").click();
-    await analyzeAccesibility(page);
+    await analyzeAccessibility(page);
   }
   await page.getByRole("link", { name: "Election Activity Log" }).click();
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
 
   // Page 1
   await page.getByText("Rejected affidavit").click();
   await page.getByText("Accepted affidavit").click();
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
 
   // Page 2
   await page.getByRole("button", { name: "Next page" }).click();
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
   await page.getByText("Voter session").click();
   await page.getByText("Ballot cast").click();
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
 
   // Page 1 again
   await page.getByRole("button", { name: "Previous page" }).click();

--- a/client/e2e/trackBallot.spec.ts
+++ b/client/e2e/trackBallot.spec.ts
@@ -39,7 +39,7 @@ test("tracking a ballot", async ({ page }) => {
 
   await page.goto("/en/organisation_slug/election_slug/track");
   await analyzeAccesibility(page);
-  await expect(page.locator("h3")).toHaveText("Ballot Tracker");
+  await expect(page.locator("h1")).toHaveText("Ballot Tracker");
   await page.locator("#tracking-code").fill("5ksv8Ee");
   await page.getByRole("button", { name: "Track my ballot" }).click();
   await analyzeAccesibility(page);
@@ -87,7 +87,7 @@ test("tracking a non-existing ballot shows an error", async ({ page }) => {
 
   await page.goto("/en/organisation_slug/election_slug/track");
   await analyzeAccesibility(page);
-  await expect(page.locator("h3")).toHaveText("Ballot Tracker");
+  await expect(page.locator("h1")).toHaveText("Ballot Tracker");
   await page.locator("#tracking-code").fill("abcdef");
   await page.getByRole("button", { name: "Track my ballot" }).click();
   await analyzeAccesibility(page);

--- a/client/e2e/trackBallot.spec.ts
+++ b/client/e2e/trackBallot.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { latestConfig, foundBallotStatus, status } from "./mocks";
-import analyzeAccesibility from "./accessibility";
+import analyzeAccessibility from "./accessibility";
 
 test("tracking a ballot", async ({ page }) => {
   // Mock Network calls
@@ -38,15 +38,15 @@ test("tracking a ballot", async ({ page }) => {
   });
 
   await page.goto("/en/organisation_slug/election_slug/track");
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
   await expect(page.locator("h1")).toHaveText("Ballot Tracker");
   await page.locator("#tracking-code").fill("5ksv8Ee");
   await page.getByRole("button", { name: "Track my ballot" }).click();
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
   await page.locator(".ExpandableSection__Expander").first().click();
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
   await page.getByRole("button", { name: "Cancel tracking 5ksv8Ee" }).click();
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
   await page.locator("#tracking-code").fill("5ksv8Ee");
 });
 
@@ -86,11 +86,11 @@ test("tracking a non-existing ballot shows an error", async ({ page }) => {
   });
 
   await page.goto("/en/organisation_slug/election_slug/track");
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
   await expect(page.locator("h1")).toHaveText("Ballot Tracker");
   await page.locator("#tracking-code").fill("abcdef");
   await page.getByRole("button", { name: "Track my ballot" }).click();
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
   await expect(page.locator(".Error__Title")).toContainText(
     "Tracking code not found",
   );

--- a/client/e2e/verifyBallot.spec.ts
+++ b/client/e2e/verifyBallot.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { latestConfig, status } from "./mocks";
-import analyzeAccesibility from "./accessibility";
+import analyzeAccessibility from "./accessibility";
 
 test("verifying a ballot", async ({ page }) => {
   // Mock Network calls
@@ -29,11 +29,11 @@ test("verifying a ballot", async ({ page }) => {
   });
 
   await page.goto("/en/organisation_slug/election_slug/verify");
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
   await expect(page.locator("h1")).toHaveText("Ballot Tester");
   await page.getByPlaceholder("Testing code").fill("5ksv8Ee");
   await page.getByRole("button", { name: "Start the Test" }).click();
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
 });
 
 test("verifying with an invalid verification code", async ({ page }) => {
@@ -77,7 +77,7 @@ test("verifying with an invalid verification code", async ({ page }) => {
   await expect(page.locator("h1")).toHaveText("Ballot Tester");
   await page.locator("#verification-code").fill("invalid-code");
   await page.getByRole("button", { name: "Start the Test" }).click();
-  await analyzeAccesibility(page);
+  await analyzeAccessibility(page);
   await expect(page.locator(".Error__Title")).toContainText(
     "Testing code not found",
   );

--- a/client/e2e/verifyBallot.spec.ts
+++ b/client/e2e/verifyBallot.spec.ts
@@ -30,7 +30,7 @@ test("verifying a ballot", async ({ page }) => {
 
   await page.goto("/en/organisation_slug/election_slug/verify");
   await analyzeAccesibility(page);
-  await expect(page.locator("h3")).toHaveText("Ballot Tester");
+  await expect(page.locator("h1")).toHaveText("Ballot Tester");
   await page.getByPlaceholder("Testing code").fill("5ksv8Ee");
   await page.getByRole("button", { name: "Start the Test" }).click();
   await analyzeAccesibility(page);
@@ -74,7 +74,7 @@ test("verifying with an invalid verification code", async ({ page }) => {
   });
 
   await page.goto("/en/organisation_slug/election_slug/verify");
-  await expect(page.locator("h3")).toHaveText("Ballot Tester");
+  await expect(page.locator("h1")).toHaveText("Ballot Tester");
   await page.locator("#verification-code").fill("invalid-code");
   await page.getByRole("button", { name: "Start the Test" }).click();
   await analyzeAccesibility(page);

--- a/client/env.d.ts
+++ b/client/env.d.ts
@@ -1,1 +1,13 @@
 /// <reference types="vite/client" />
+
+export {};
+
+declare module "@vitest/expect" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface Assertion<T = any> {
+    toHaveNoViolations(): Promise<void>;
+  }
+  interface AsymmetricMatchersContaining {
+    toHaveNoViolations(): Promise<void>;
+  }
+}

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,10 +1,10 @@
 import pluginVue from "eslint-plugin-vue";
-import vueTsEslintConfig from "@vue/eslint-config-typescript";
+import { defineConfigWithVueTs, vueTsConfigs } from "@vue/eslint-config-typescript";
 import pluginVitest from "@vitest/eslint-plugin";
 import skipFormatting from "@vue/eslint-config-prettier/skip-formatting";
 import vuejsA11y from "eslint-plugin-vuejs-accessibility";
 
-export default [
+export default defineConfigWithVueTs(
   {
     name: "app/files-to-lint",
     files: ["src/**/*.{ts,mts,tsx,vue}"],
@@ -20,9 +20,9 @@ export default [
     ],
   },
 
-  ...pluginVue.configs["flat/essential"],
-  ...vueTsEslintConfig(),
-  ...vuejsA11y.configs["flat/recommended"],
+  pluginVue.configs["flat/essential"],
+  vueTsConfigs.recommended,
+  vuejsA11y.configs["flat/recommended"],
 
   {
     ...pluginVitest.configs.recommended,
@@ -58,7 +58,7 @@ export default [
       "vuejs-accessibility/heading-has-content": "warn",
       "vuejs-accessibility/iframe-has-title": "warn",
       "vuejs-accessibility/interactive-supports-focus": "warn",
-      "vuejs-accessibility/label-has-for": "warn",
+      "vuejs-accessibility/label-has-for": ["warn", { required: { some: ["nesting", "id"] }, allowChildren: true }],
       "vuejs-accessibility/media-has-caption": "warn",
       "vuejs-accessibility/mouse-events-have-key-events": "warn",
       "vuejs-accessibility/no-access-key": "warn",
@@ -70,4 +70,4 @@ export default [
       "vuejs-accessibility/tabindex-no-positive": "warn",
     },
   },
-];
+);

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -2,6 +2,7 @@ import pluginVue from "eslint-plugin-vue";
 import vueTsEslintConfig from "@vue/eslint-config-typescript";
 import pluginVitest from "@vitest/eslint-plugin";
 import skipFormatting from "@vue/eslint-config-prettier/skip-formatting";
+import vuejsA11y from "eslint-plugin-vuejs-accessibility";
 
 export default [
   {
@@ -21,6 +22,7 @@ export default [
 
   ...pluginVue.configs["flat/essential"],
   ...vueTsEslintConfig(),
+  ...vuejsA11y.configs["flat/recommended"],
 
   {
     ...pluginVitest.configs.recommended,
@@ -45,6 +47,27 @@ export default [
           caughtErrorsIgnorePattern: "^_",
         },
       ],
+
+      "vuejs-accessibility/alt-text": "warn",
+      "vuejs-accessibility/anchor-has-content": "warn",
+      "vuejs-accessibility/aria-props": "warn",
+      "vuejs-accessibility/aria-role": "warn",
+      "vuejs-accessibility/aria-unsupported-elements": "warn",
+      "vuejs-accessibility/click-events-have-key-events": "warn",
+      "vuejs-accessibility/form-control-has-label": "warn",
+      "vuejs-accessibility/heading-has-content": "warn",
+      "vuejs-accessibility/iframe-has-title": "warn",
+      "vuejs-accessibility/interactive-supports-focus": "warn",
+      "vuejs-accessibility/label-has-for": "warn",
+      "vuejs-accessibility/media-has-caption": "warn",
+      "vuejs-accessibility/mouse-events-have-key-events": "warn",
+      "vuejs-accessibility/no-access-key": "warn",
+      "vuejs-accessibility/no-autofocus": "warn",
+      "vuejs-accessibility/no-distracting-elements": "warn",
+      "vuejs-accessibility/no-redundant-roles": "warn",
+      "vuejs-accessibility/no-static-element-interactions": "warn",
+      "vuejs-accessibility/role-has-required-aria-props": "warn",
+      "vuejs-accessibility/tabindex-no-positive": "warn",
     },
   },
 ];

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,5 +1,8 @@
 import pluginVue from "eslint-plugin-vue";
-import { defineConfigWithVueTs, vueTsConfigs } from "@vue/eslint-config-typescript";
+import {
+  defineConfigWithVueTs,
+  vueTsConfigs,
+} from "@vue/eslint-config-typescript";
 import pluginVitest from "@vitest/eslint-plugin";
 import skipFormatting from "@vue/eslint-config-prettier/skip-formatting";
 import vuejsA11y from "eslint-plugin-vuejs-accessibility";
@@ -58,7 +61,10 @@ export default defineConfigWithVueTs(
       "vuejs-accessibility/heading-has-content": "warn",
       "vuejs-accessibility/iframe-has-title": "warn",
       "vuejs-accessibility/interactive-supports-focus": "warn",
-      "vuejs-accessibility/label-has-for": ["warn", { required: { some: ["nesting", "id"] }, allowChildren: true }],
+      "vuejs-accessibility/label-has-for": [
+        "warn",
+        { required: { some: ["nesting", "id"] }, allowChildren: true },
+      ],
       "vuejs-accessibility/media-has-caption": "warn",
       "vuejs-accessibility/mouse-events-have-key-events": "warn",
       "vuejs-accessibility/no-access-key": "warn",

--- a/client/package.json
+++ b/client/package.json
@@ -21,8 +21,8 @@
     "lint:ci": "eslint ./src/**/*"
   },
   "dependencies": {
-    "@assemblyvoting/electa-ui": "5.6.5-beta.1",
-    "@assemblyvoting/js-client": "^6.1.0",
+    "@assemblyvoting/electa-ui": "5.6.6-beta.2",
+    "@assemblyvoting/js-client": "^6.3.0",
     "axios": "^1.17.0",
     "date-fns": "^4.4.0",
     "date-fns-tz": "^3.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -53,10 +53,13 @@
     "eslint": "^10.4.1",
     "eslint-plugin-json": "^4.0.1",
     "eslint-plugin-vue": "^10.9.2",
+    "eslint-plugin-vuejs-accessibility": "^2.5.0",
+    "globals": "^17.6.0",
     "prettier": "^3.8.3",
     "typescript": "^5.4.5",
     "vite": "^8.0.16",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "vitest-axe": "^0.1.0"
   },
   "engines": {
     "node": ">=24.14.0",

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -56,12 +56,12 @@ const config: PlaywrightTestConfig = {
         ...devices["Desktop Chrome"],
       },
     },
-    {
-      name: "firefox",
-      use: {
-        ...devices["Desktop Firefox"],
-      },
-    },
+    // {
+    //   name: "firefox",
+    //   use: {
+    //     ...devices["Desktop Firefox"],
+    //   },
+    // },
 
     /* Test against mobile viewports. */
     {
@@ -70,12 +70,12 @@ const config: PlaywrightTestConfig = {
         ...devices["Pixel 5"],
       },
     },
-    {
-      name: "Mobile Safari",
-      use: {
-        ...devices["iPhone 12"],
-      },
-    },
+    // {
+    //   name: "Mobile Safari",
+    //   use: {
+    //     ...devices["iPhone 12"],
+    //   },
+    // },
 
     /* Test against branded browsers. */
     // {

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -128,7 +128,8 @@ const setTheme = async (conferenceClient: any) => {
 </script>
 
 <template>
-  <div v-if="!isLoaded" class="DBAS__Loading_Page">
+  <div v-if="!isLoaded" class="DBAS__Loading_Page" role="main">
+    <h1 class="visually-hidden">{{ $t("js.components.AVSpinner.loading") }}</h1>
     <AVSpinner size="lg" color="dark" />
   </div>
   <div class="DBAS" v-if="isLoaded">

--- a/client/src/components/BallotActivity.a11y.test.ts
+++ b/client/src/components/BallotActivity.a11y.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "vitest";
+import { axe } from "vitest-axe";
+import { mountForA11y } from "../test-utils/a11y";
+import BallotActivity from "./BallotActivity.vue";
+
+test("has no accessibility violations in default state", async () => {
+  const wrapper = await mountForA11y(BallotActivity, {
+    props: {
+      activity: {
+        registeredAt: "2022-03-02T00:10:12+0100",
+        type: "some_type",
+      },
+      index: 0,
+    },
+  });
+  const results = await axe(wrapper.element);
+  await expect(results).toHaveNoViolations();
+  wrapper.unmount();
+});

--- a/client/src/components/BallotActivityList.a11y.test.ts
+++ b/client/src/components/BallotActivityList.a11y.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "vitest";
+import { axe } from "vitest-axe";
+import { mountForA11y } from "../test-utils/a11y";
+import BallotActivityList from "./BallotActivityList.vue";
+
+test("has no accessibility violations with activities", async () => {
+  const wrapper = await mountForA11y(BallotActivityList, {
+    props: {
+      activities: [
+        {
+          type: "SessionItem",
+          registeredAt: "2023-01-01T10:00:00+0100",
+        },
+      ],
+    },
+  });
+  const results = await axe(wrapper.element);
+  await expect(results).toHaveNoViolations();
+  wrapper.unmount();
+});

--- a/client/src/components/BallotVerifierContest.vue
+++ b/client/src/components/BallotVerifierContest.vue
@@ -37,7 +37,11 @@
 import useConfigStore from "@/stores/useConfigStore";
 import type { PropType } from "vue";
 import { defineComponent } from "vue";
-import type { ContestSelection, ContestContent, SupportedLocale } from "@/Types";
+import type {
+  ContestSelection,
+  ContestContent,
+  SupportedLocale,
+} from "@/Types";
 
 export default defineComponent({
   name: "BallotVerifierContest",

--- a/client/src/components/BallotVerifierContest.vue
+++ b/client/src/components/BallotVerifierContest.vue
@@ -7,11 +7,11 @@
       class="BallotVerifierContest__Title"
       :id="`contest-title-${contestSelection.reference}`"
     >
-      {{ contest.title[$i18n.locale as SupportedLocale] }}
+      {{ contestTitle }}
     </h3>
     <p
       v-if="contest.question"
-      v-text="contest.question[$i18n.locale as SupportedLocale]"
+      v-text="contestQuestion"
       :id="`contest-question-${contestSelection.reference}`"
     ></p>
     <div
@@ -37,12 +37,7 @@
 import useConfigStore from "@/stores/useConfigStore";
 import type { PropType } from "vue";
 import { defineComponent } from "vue";
-import type {
-  ContestSelection,
-  ContestContent,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  SupportedLocale,
-} from "@/Types";
+import type { ContestSelection, ContestContent, SupportedLocale } from "@/Types";
 
 export default defineComponent({
   name: "BallotVerifierContest",
@@ -58,6 +53,12 @@ export default defineComponent({
     },
     contest(): ContestContent {
       return this.configStore.getContest(this.contestSelection.reference);
+    },
+    contestTitle(): string {
+      return this.contest.title[this.$i18n.locale as SupportedLocale];
+    },
+    contestQuestion(): string | undefined {
+      return this.contest.question?.[this.$i18n.locale as SupportedLocale];
     },
   },
 });

--- a/client/src/components/BoardItem.a11y.test.ts
+++ b/client/src/components/BoardItem.a11y.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "vitest";
+import { axe } from "vitest-axe";
+import BoardItem from "./BoardItem.vue";
+import { mountForA11y } from "../test-utils/a11y";
+
+test("has no accessibility violations in default state", async () => {
+  const wrapper = await mountForA11y(BoardItem, {
+    props: {
+      item: {
+        type: "VoterSessionItem",
+        address:
+          "00dd8a9310e8d572e53fb297e96758ded086f424df7ad63dd9ee5639ce13d281",
+      },
+    },
+  });
+  const results = await axe(wrapper.element);
+  await expect(results).toHaveNoViolations();
+  wrapper.unmount();
+});

--- a/client/src/components/ContentLayout.a11y.test.ts
+++ b/client/src/components/ContentLayout.a11y.test.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "vitest";
+import { axe } from "vitest-axe";
+import ContentLayout from "./ContentLayout.vue";
+import { mountForA11y } from "../test-utils/a11y";
+
+test("has no accessibility violations in default state", async () => {
+  const wrapper = await mountForA11y(ContentLayout, {
+    props: {
+      helpTitle: "Help title",
+      helpTitleStrong: " strong part",
+    },
+    slots: {
+      action: "<p>Action content</p>",
+      help: "<p>Help content</p>",
+    },
+  });
+  const results = await axe(wrapper.element);
+  await expect(results).toHaveNoViolations();
+  wrapper.unmount();
+});
+
+test("has no accessibility violations with breadcrumb and logo", async () => {
+  const wrapper = await mountForA11y(ContentLayout, {
+    props: {
+      helpTitle: "Help title",
+      helpTitleStrong: " strong part",
+      breadcrumb: "Home > Verify",
+      logo: "https://example.com/logo.png",
+    },
+    slots: {
+      action: "<p>Action content</p>",
+      help: "<p>Help content</p>",
+    },
+  });
+  const results = await axe(wrapper.element);
+  await expect(results).toHaveNoViolations();
+  wrapper.unmount();
+});

--- a/client/src/components/ContentLayout.test.ts
+++ b/client/src/components/ContentLayout.test.ts
@@ -24,7 +24,7 @@ test("renders correctly", async () => {
   });
 
   expect(wrapper.find("section").text()).toContain("something");
-  expect(wrapper.find("h5").text()).toContain("titlestrong");
+  expect(wrapper.find("h2").text()).toContain("titlestrong");
   expect(wrapper.find("aside").text()).toContain("sidebar");
   expect(wrapper.html()).to.not.contain("ContentLayout__Breadcrumb");
   expect(wrapper.html()).to.not.contain("ContentLayout__Brand_Logo");

--- a/client/src/components/ContentLayout.vue
+++ b/client/src/components/ContentLayout.vue
@@ -46,12 +46,12 @@ defineProps({
       class="ContentLayout__Help"
       :aria-label="$t('accessibility.help')"
     >
-      <h5 class="ContentLayout__Help_Title" id="content-layout-help-title">
+      <h2 class="ContentLayout__Help_Title" id="content-layout-help-title">
         {{ helpTitle
         }}<strong id="content-layout-help-title-strong">{{
           helpTitleStrong
         }}</strong>
-      </h5>
+      </h2>
 
       <div
         class="ContentLayout__Help_Container"

--- a/client/src/components/ContentLayout.vue
+++ b/client/src/components/ContentLayout.vue
@@ -41,10 +41,13 @@ defineProps({
         <slot name="action" />
       </div>
     </section>
+    <!-- tabindex is required for keyboard-scrollable content in Safari (WCAG 2.1.1) -->
+    <!-- sonarqube-disable-next-line sonar/no-tabindex-on-non-interactive-elements -->
     <aside
       id="help-content-aside"
       class="ContentLayout__Help"
       :aria-label="$t('accessibility.help')"
+      tabindex="0"
     >
       <h2 class="ContentLayout__Help_Title" id="content-layout-help-title">
         {{ helpTitle

--- a/client/src/components/ContentLayout.vue
+++ b/client/src/components/ContentLayout.vue
@@ -45,7 +45,6 @@ defineProps({
       id="help-content-aside"
       class="ContentLayout__Help"
       :aria-label="$t('accessibility.help')"
-      tabindex="0"
     >
       <h5 class="ContentLayout__Help_Title" id="content-layout-help-title">
         {{ helpTitle

--- a/client/src/components/DateTime.vue
+++ b/client/src/components/DateTime.vue
@@ -14,7 +14,7 @@ const props = defineProps({
   format: {
     type: String,
     default: "relative",
-    validate: (s: string) => ["absolute", "relative"].indexOf(s) >= 0,
+    validate: (s: string) => ["absolute", "relative"].includes(s),
   },
   timeZone: {
     type: String,

--- a/client/src/components/ExpandableSection.a11y.test.ts
+++ b/client/src/components/ExpandableSection.a11y.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "vitest";
+import { axe } from "vitest-axe";
+import ExpandableSection from "./ExpandableSection.vue";
+import { mountForA11y } from "../test-utils/a11y";
+
+test("has no accessibility violations when collapsed", async () => {
+  const wrapper = await mountForA11y(ExpandableSection, {
+    props: { expanded: false },
+    slots: {
+      collapsed: "Collapsed content",
+      expanded: "Expanded content",
+    },
+  });
+  const results = await axe(wrapper.element);
+  await expect(results).toHaveNoViolations();
+  wrapper.unmount();
+});
+
+test("has no accessibility violations when expanded", async () => {
+  const wrapper = await mountForA11y(ExpandableSection, {
+    props: { expanded: true },
+    slots: {
+      collapsed: "Collapsed content",
+      expanded: "Expanded content",
+    },
+  });
+  const results = await axe(wrapper.element);
+  await expect(results).toHaveNoViolations();
+  wrapper.unmount();
+});

--- a/client/src/components/ExpandableSection.vue
+++ b/client/src/components/ExpandableSection.vue
@@ -22,13 +22,14 @@ const toggle = () => {
 </script>
 
 <template>
-  <div
+  <button
     @click="toggle"
     class="ExpandableSection"
     :class="{
       ['ExpandableSection--expanded']: _expanded,
     }"
-    role="button"
+    type="button"
+    :aria-expanded="_expanded"
   >
     <div class="ExpandableSection__Line" v-if="!_expanded">
       <slot name="collapsed"></slot>
@@ -43,7 +44,7 @@ const toggle = () => {
 
       <AVIcon v-else icon="plus" aria-hidden="true" />
     </span>
-  </div>
+  </button>
 </template>
 
 <style type="text/css" scoped>
@@ -58,6 +59,8 @@ const toggle = () => {
   background-color: white;
   z-index: 10;
   cursor: pointer;
+  width: 100%;
+  text-align: left;
 }
 
 .ExpandableSection__Line {

--- a/client/src/components/ExpandableSection.vue
+++ b/client/src/components/ExpandableSection.vue
@@ -19,16 +19,26 @@ const toggle = () => {
     ? t("components.board_item.collapse")
     : t("components.board_item.expand");
 };
+
+const onKeydown = (event: KeyboardEvent) => {
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    toggle();
+  }
+};
 </script>
 
 <template>
-  <button
+  <!-- NOSONAR: using div with role=button instead of <button> because slots render block-level content, which is invalid inside <button> -->
+  <div
     @click="toggle"
+    @keydown="onKeydown"
     class="ExpandableSection"
     :class="{
       ['ExpandableSection--expanded']: _expanded,
     }"
-    type="button"
+    role="button"
+    tabindex="0"
     :aria-expanded="_expanded"
   >
     <div class="ExpandableSection__Line" v-if="!_expanded">
@@ -44,7 +54,7 @@ const toggle = () => {
 
       <AVIcon v-else icon="plus" aria-hidden="true" />
     </span>
-  </button>
+  </div>
 </template>
 
 <style type="text/css" scoped>

--- a/client/src/components/Header.vue
+++ b/client/src/components/Header.vue
@@ -67,7 +67,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="Header__Navbar" id="header-navbar">
+  <header class="Header__Navbar" id="header-navbar">
     <RouterLink
       class="Header__Election_Info"
       :to="`/${locale}/${route.params.organisationSlug}/${route.params.electionSlug}`"
@@ -168,7 +168,7 @@ onBeforeUnmount(() => {
         id="header-hamburger-menu-button"
       />
     </div>
-  </div>
+  </header>
 </template>
 
 <style type="text/css" scoped>

--- a/client/src/components/Header.vue
+++ b/client/src/components/Header.vue
@@ -58,11 +58,11 @@ const setLocale = (newLocale: string) => {
 const onResize = () => (isMenuOpened.value = false);
 
 onMounted(() => {
-  window.addEventListener("resize", onResize);
+  globalThis.addEventListener("resize", onResize);
 });
 
 onBeforeUnmount(() => {
-  window.removeEventListener("resize", onResize);
+  globalThis.removeEventListener("resize", onResize);
 });
 </script>
 

--- a/client/src/components/TrackedBallotManager.a11y.test.ts
+++ b/client/src/components/TrackedBallotManager.a11y.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "vitest";
+import { axe } from "vitest-axe";
+import TrackedBallotManager from "./TrackedBallotManager.vue";
+import { mountForA11y } from "../test-utils/a11y";
+
+test("has no accessibility violations with tracking code", async () => {
+  const wrapper = await mountForA11y(TrackedBallotManager, {
+    props: { trackingCode: "ABDCEF" },
+  });
+  const results = await axe(wrapper.element);
+  await expect(results).toHaveNoViolations();
+  wrapper.unmount();
+});

--- a/client/src/composables/__tests__/useElectionBranding.test.ts
+++ b/client/src/composables/__tests__/useElectionBranding.test.ts
@@ -214,16 +214,20 @@ describe("useElectionBranding", () => {
   });
 
   describe("resetBranding", () => {
-    it("resets favicon to default", () => {
-      const { branding } = mountWithBranding({
+    it("resets favicon and document title to defaults", () => {
+      const { branding, setTitle } = mountWithBranding({
         faviconUrl: "/custom-favicon.ico",
+        tabName: { en: "Custom Tab" },
       });
+      setTitle("en");
+      expect(document.title).toBe("Custom Tab");
 
       branding.resetBranding();
 
       const faviconLink =
         document.querySelector<HTMLLinkElement>("link[rel*='icon']");
       expect(faviconLink?.href).toContain("/favicon.ico");
+      expect(document.title).toBe("Election Verification Site");
     });
   });
 

--- a/client/src/composables/useElectionBranding.ts
+++ b/client/src/composables/useElectionBranding.ts
@@ -65,6 +65,7 @@ export function useElectionBranding() {
 
   const resetBranding = () => {
     currentFaviconUrl.value = DEFAULT_FAVICON_URL;
+    document.title = DEFAULT_TAB_NAME;
 
     const faviconLink =
       document.querySelector<HTMLLinkElement>("link[rel*='icon']");

--- a/client/src/lib/conferenceServices.ts
+++ b/client/src/lib/conferenceServices.ts
@@ -37,9 +37,9 @@ export function useConferenceConnector(
         return (status as any).election as ExtendedElectionStatusResponse;
       },
       async getStylingData() {
-        return (await conferenceApi.value.get(
+        return conferenceApi.value.get<string>(
           `/${organisationSlug}/${electionSlug}/theme`,
-        )) as string;
+        );
       },
       async getTranslationsData(locale: SupportedLocale) {
         if (!currentTranslationsData.value) {

--- a/client/src/lib/config.ts
+++ b/client/src/lib/config.ts
@@ -1,4 +1,4 @@
-const myWindow = window as unknown as {
+const myWindow = globalThis as unknown as {
   __APP_CONFIG__: {
     VITE_LOGO_URL: string; // Unused?
     VITE_DBB_URL: string;

--- a/client/src/lib/httpErrorHandler.ts
+++ b/client/src/lib/httpErrorHandler.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-export default (error: any) => {
+export default function httpErrorHandler(error: any) {
   if (error === null) throw new Error("Unrecoverable error!! Error is null!");
   if (axios.isAxiosError(error)) {
     //here we have a type guard check, error inside this if will be treated as AxiosError

--- a/client/src/lib/httpErrorHandler.ts
+++ b/client/src/lib/httpErrorHandler.ts
@@ -30,4 +30,4 @@ export default function httpErrorHandler(error: any) {
 
   //Something happened in setting up the request and triggered an Error
   console.log(error.message);
-};
+}

--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -4,7 +4,7 @@ import type { Locale, DefineLocaleMessage } from "vue-i18n";
 import { offlineMessages } from "@/assets/translations";
 
 let locale: Locale = "en";
-const rtlLanguages: Locale[] = [
+const rtlLanguages: Set<Locale> = new Set([
   "ar",
   "dv",
   "fa",
@@ -15,8 +15,8 @@ const rtlLanguages: Locale[] = [
   "ps",
   "ur",
   "yi",
-];
-const url = new URL(window.location.href);
+]);
+const url = new URL(globalThis.location.href);
 if (url.pathname.split("/")[1]) locale = url.pathname.split("/")[1];
 
 const i18n = createI18n({
@@ -31,9 +31,7 @@ export function setLocale(locale: Locale) {
 
   document.getElementsByTagName("html")[0].lang = locale;
 
-  rtlLanguages.includes(locale)
-    ? (document.getElementsByTagName("html")[0].dir = "rtl")
-    : (document.getElementsByTagName("html")[0].dir = "ltr");
+  document.getElementsByTagName("html")[0].dir = rtlLanguages.has(locale) ? "rtl" : "ltr";
 }
 
 export function loadLocaleMessages(locale: string, messages: object) {

--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -16,8 +16,19 @@ const rtlLanguages: Set<Locale> = new Set([
   "ur",
   "yi",
 ]);
-const url = new URL(globalThis.location.href);
-if (url.pathname.split("/")[1]) locale = url.pathname.split("/")[1];
+
+function getLocaleFromUrl(): Locale {
+  try {
+    const url = new URL(globalThis.location.href);
+    const segment = url.pathname.split("/")[1];
+    if (segment) return segment as Locale;
+  } catch {
+    // SSR or test environment
+  }
+  return "en";
+}
+
+locale = getLocaleFromUrl();
 
 const i18n = createI18n({
   legacy: false,
@@ -31,7 +42,9 @@ export function setLocale(locale: Locale) {
 
   document.getElementsByTagName("html")[0].lang = locale;
 
-  document.getElementsByTagName("html")[0].dir = rtlLanguages.has(locale) ? "rtl" : "ltr";
+  document.getElementsByTagName("html")[0].dir = rtlLanguages.has(locale)
+    ? "rtl"
+    : "ltr";
 }
 
 export function loadLocaleMessages(locale: string, messages: object) {

--- a/client/src/lib/receiptPDFExtractor.ts
+++ b/client/src/lib/receiptPDFExtractor.ts
@@ -10,41 +10,24 @@ export class ReceiptPDFExtractor {
   }
 
   public async extract(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      // FileReader api
-      const reader = new FileReader();
-      reader.onload = async () => {
-        try {
-          const pdfDoc = await PDFDocument.load(reader.result, {
-            updateMetadata: false,
-          });
-
-          const infoRef = pdfDoc.context.trailerInfo.Info;
-          const infoDict = pdfDoc.context.lookup(infoRef) as PDFDict;
-
-          const receipt = infoDict.lookup(
-            PDFName.of("Receipt"),
-          ) as PDFHexString;
-          const trackingCode = infoDict.lookup(
-            PDFName.of("TrackingCode"),
-          ) as PDFHexString;
-
-          if (receipt == null || trackingCode == null) {
-            reject("Invalid receipt file");
-          }
-
-          this.receipt = receipt.decodeText();
-          this.trackingCode = trackingCode.decodeText();
-
-          resolve();
-        } catch (err) {
-          reject(err);
-        }
-      };
-      reader.onerror = () => {
-        reject("Could not load receipt file");
-      };
-      reader.readAsArrayBuffer(this.file);
+    const buffer = await this.file.arrayBuffer();
+    const pdfDoc = await PDFDocument.load(buffer, {
+      updateMetadata: false,
     });
+
+    const infoRef = pdfDoc.context.trailerInfo.Info;
+    const infoDict = pdfDoc.context.lookup(infoRef) as PDFDict;
+
+    const receipt = infoDict.lookup(PDFName.of("Receipt")) as PDFHexString;
+    const trackingCode = infoDict.lookup(
+      PDFName.of("TrackingCode"),
+    ) as PDFHexString;
+
+    if (receipt == null || trackingCode == null) {
+      throw new Error("Invalid receipt file");
+    }
+
+    this.receipt = receipt.decodeText();
+    this.trackingCode = trackingCode.decodeText();
   }
 }

--- a/client/src/lib/useAVVerifier.ts
+++ b/client/src/lib/useAVVerifier.ts
@@ -3,7 +3,7 @@ import config from "./config";
 
 export default async function useAVVerifier(slug: string) {
   const url = `${config.dbbUrl}/${slug}`;
-  const avVerifier = await new AVVerifier(url);
+  const avVerifier = new AVVerifier(url);
   await avVerifier.initialize();
   return avVerifier;
 }

--- a/client/src/test-utils/a11y.ts
+++ b/client/src/test-utils/a11y.ts
@@ -1,0 +1,44 @@
+import { mount } from "@vue/test-utils";
+import type { MountingOptions } from "@vue/test-utils";
+import type { Component } from "vue";
+import { createI18n } from "vue-i18n";
+import { expect } from "vitest";
+import { toHaveNoViolations } from "vitest-axe/dist/matchers.js";
+import { fallbackMessages } from "../assets/translations";
+
+expect.extend({ toHaveNoViolations });
+
+const neededStrings = JSON.stringify(fallbackMessages.en);
+const messages = { en: JSON.parse(neededStrings) };
+
+const defaultStubs = {
+  AVIcon: { template: "<span />" },
+  AVTooltip: { template: "<span />" },
+  DateTime: { template: "<span />" },
+};
+
+const i18n = createI18n({ messages });
+
+interface A11yMountOptions extends Omit<Partial<MountingOptions<any>>, 'attachTo'> {
+  attachTo?: boolean;
+}
+
+export async function mountForA11y(
+  component: Component,
+  options: A11yMountOptions = {},
+) {
+  const { attachTo, ...rest } = options;
+  const wrapper = mount(component, {
+    ...rest,
+    attachTo: attachTo === false ? undefined : document.body,
+    global: {
+      plugins: [i18n],
+      stubs: defaultStubs,
+      ...rest.global,
+    },
+  });
+
+  return wrapper;
+}
+
+export { i18n, defaultStubs };

--- a/client/src/test-utils/a11y.ts
+++ b/client/src/test-utils/a11y.ts
@@ -19,7 +19,10 @@ const defaultStubs = {
 
 const i18n = createI18n({ messages });
 
-interface A11yMountOptions extends Omit<Partial<MountingOptions<any>>, 'attachTo'> {
+interface A11yMountOptions extends Omit<
+  Partial<MountingOptions<any>>,
+  "attachTo"
+> {
   attachTo?: boolean;
 }
 
@@ -28,15 +31,28 @@ export async function mountForA11y(
   options: A11yMountOptions = {},
 ) {
   const { attachTo, ...rest } = options;
+  const container =
+    attachTo === false ? undefined : document.createElement("div");
+  if (container) {
+    document.body.appendChild(container);
+  }
   const wrapper = mount(component, {
     ...rest,
-    attachTo: attachTo === false ? undefined : document.body,
+    attachTo: container,
     global: {
       plugins: [i18n],
       stubs: defaultStubs,
       ...rest.global,
     },
   });
+
+  const originalUnmount = wrapper.unmount.bind(wrapper);
+  wrapper.unmount = () => {
+    originalUnmount();
+    if (container && container.parentElement) {
+      container.parentElement.removeChild(container);
+    }
+  };
 
   return wrapper;
 }

--- a/client/src/views/BallotTrackerView.vue
+++ b/client/src/views/BallotTrackerView.vue
@@ -45,9 +45,9 @@ onMounted(() => (ballot.value = ballotStore.ballot));
           @cancel="cancel"
         />
 
-        <h3 class="BallotTracker__Title" id="tracker-title">
+        <h1 class="BallotTracker__Title" id="tracker-title">
           {{ $t("views.tracker.info.title") }}
-        </h3>
+        </h1>
         <p class="BallotTracker__Description" id="tracker-description">
           {{ $t("views.tracker.info.description") }}
         </p>

--- a/client/src/views/BallotTrackingLanding.vue
+++ b/client/src/views/BallotTrackingLanding.vue
@@ -97,15 +97,15 @@ const button = computed(() => {
   >
     <template v-slot:action>
       <MainIcon icon="magnifying-glass" id="tracking-main-icon" />
-      <h3 class="TrackingLanding__Title" id="tracking-title">
+      <h1 class="TrackingLanding__Title" id="tracking-title">
         {{ $t("views.tracking.title") }}
-      </h3>
-      <h4 class="TrackingLanding__Subtitle" id="tracking-subtitle">
+      </h1>
+      <h2 class="TrackingLanding__Subtitle" id="tracking-subtitle">
         {{ $t("views.tracking.subtitle") }}
         <strong id="tracking-subtitle-strong">{{
           $t("views.tracking.subtitle_strong")
         }}</strong>
-      </h4>
+      </h2>
       <p class="TrackingLanding__Description" id="tracking-description">
         {{ $t("views.tracking.description") }}
       </p>

--- a/client/src/views/BallotVerificationLanding.vue
+++ b/client/src/views/BallotVerificationLanding.vue
@@ -99,6 +99,7 @@ watch(verificationStore, async (newStore) => {
               class="text-gray-600 cursor-help"
               v-tooltip="$t('views.verification.tooltip_text')"
               id="verification-tooltip-icon"
+              aria-hidden="true"
             />
           </label>
           <input

--- a/client/src/views/BallotVerificationLanding.vue
+++ b/client/src/views/BallotVerificationLanding.vue
@@ -70,15 +70,15 @@ watch(verificationStore, async (newStore) => {
   >
     <template v-slot:action>
       <MainIcon icon="envelope-open-text" id="verification-main-icon" />
-      <h3 class="VerificationLanding__Title" id="verification-title">
+      <h1 class="VerificationLanding__Title" id="verification-title">
         {{ $t("views.verification.title") }}
-      </h3>
-      <h4 class="VerificationLanding__Subtitle" id="verification-subtitle">
+      </h1>
+      <h2 class="VerificationLanding__Subtitle" id="verification-subtitle">
         {{ $t("views.verification.subtitle") }}
         <strong id="verification-subtitle-strong">{{
           $t("views.verification.subtitle_strong")
         }}</strong>
-      </h4>
+      </h2>
       <p class="VerificationLanding__Description" id="verification-description">
         {{ $t("views.verification.description") }}
       </p>

--- a/client/src/views/BallotVerifierFoundView.vue
+++ b/client/src/views/BallotVerifierFoundView.vue
@@ -79,9 +79,9 @@ onMounted(async () => {
         />
 
         <MainIcon icon="envelope-open-text" id="verifier-found-main-icon" />
-        <h3 class="VerificationFound__Title" id="verifier-found-title">
+        <h1 class="VerificationFound__Title" id="verifier-found-title">
           {{ $t("views.verifier.found.title") }}
-        </h3>
+        </h1>
         <p
           class="VerificationFound__Description"
           id="verifier-found-description"

--- a/client/src/views/BallotVerifierView.vue
+++ b/client/src/views/BallotVerifierView.vue
@@ -69,12 +69,12 @@ onMounted(() => {
           id="verifier-spoiled-content"
         >
           <MainIcon icon="spell-check" id="verifier-spoiled-icon" />
-          <h3
+          <h1
             class="BallotVerifier__Title_Secondary"
             id="verifier-spoiled-title"
           >
             {{ $t("views.verifier.spoiled.title") }}
-          </h3>
+          </h1>
           <p class="BallotVerifier__Title" id="verifier-spoiled-description">
             {{ $t("views.verifier.spoiled.description") }}
           </p>
@@ -106,12 +106,12 @@ onMounted(() => {
           id="verifier-inprogress-content"
         >
           <MainIcon icon="asterisk" id="verifier-inprogress-icon" />
-          <h3
+          <h1
             class="BallotVerifier__Title BallotVerifier__Title_Passkey"
             id="verifier-inprogress-title"
           >
             {{ $t("views.verifier.inprogress.title") }}
-          </h3>
+          </h1>
 
           <div
             v-if="showAlert"

--- a/client/src/views/HelpView.vue
+++ b/client/src/views/HelpView.vue
@@ -159,11 +159,11 @@ onMounted(() => {
           :id="`help-faq-${index}`"
         >
           <template v-slot:collapsed>
-             <h2 class="HelpView__FAQ_Title">{{ question.title }}</h2>
+            <h2 class="HelpView__FAQ_Title">{{ question.title }}</h2>
           </template>
 
           <template v-slot:expanded>
-             <h2 class="HelpView__FAQ_Title mb-3">{{ question.title }}</h2>
+            <h2 class="HelpView__FAQ_Title mb-3">{{ question.title }}</h2>
             <p
               v-for="(p, i) in question.paragraphs"
               :key="`${i}-${p}`"

--- a/client/src/views/HelpView.vue
+++ b/client/src/views/HelpView.vue
@@ -67,9 +67,9 @@ onMounted(() => {
   >
     <template v-slot:action>
       <MainIcon icon="circle-question" id="help-main-icon" />
-      <h2 class="HelpView__Title" id="help-title">
+      <h1 class="HelpView__Title" id="help-title">
         {{ $t("views.faq.title") }}
-      </h2>
+      </h1>
       <p class="HelpView__Description" id="help-description">
         {{ $t("views.faq.description") }}
       </p>
@@ -159,11 +159,11 @@ onMounted(() => {
           :id="`help-faq-${index}`"
         >
           <template v-slot:collapsed>
-            <h3 class="HelpView__FAQ_Title">{{ question.title }}</h3>
+             <h2 class="HelpView__FAQ_Title">{{ question.title }}</h2>
           </template>
 
           <template v-slot:expanded>
-            <h3 class="HelpView__FAQ_Title mb-3">{{ question.title }}</h3>
+             <h2 class="HelpView__FAQ_Title mb-3">{{ question.title }}</h2>
             <p
               v-for="(p, i) in question.paragraphs"
               :key="`${i}-${p}`"

--- a/client/src/views/LogsView.vue
+++ b/client/src/views/LogsView.vue
@@ -102,12 +102,12 @@ onMounted(async () => {
   >
     <template v-slot:action>
       <MainIcon icon="square-poll-vertical" id="logs-main-icon" />
-      <h3 class="LogsView__Subtitle" id="logs-subtitle">
+      <h1 class="LogsView__Subtitle" id="logs-subtitle">
         {{ $t("views.logs.subtitle") }}
-      </h3>
-      <h4 class="LogsView__Title" id="logs-title">
+      </h1>
+      <h2 class="LogsView__Title" id="logs-title">
         {{ $t("views.logs.title") }}
-      </h4>
+      </h2>
       <p class="LogsView__Description" id="logs-description">
         {{ $t("views.logs.description") }}
       </p>

--- a/client/src/views/ReceiptErrorView.vue
+++ b/client/src/views/ReceiptErrorView.vue
@@ -79,9 +79,9 @@ const buttons = computed(() => {
         :icon="receiptStore.receiptValid ? 'circle-xmark' : 'file-circle-xmark'"
         id="receipt-error-main-icon"
       />
-      <h3 class="ReceiptError__Title" id="receipt-error-title">
+      <h1 class="ReceiptError__Title" id="receipt-error-title">
         {{ $t(`views.receipt_error.${translationPath}.title`) }}
-      </h3>
+      </h1>
 
       <Error
         :errorPath="`receipt.${translationPath}`"

--- a/client/src/views/Welcome.vue
+++ b/client/src/views/Welcome.vue
@@ -21,17 +21,23 @@ const goToTracker = () => {
 
 <template>
   <div class="Welcome" id="welcome">
+    <h1
+      class="Welcome__Description_Desktop_Title visually-hidden-mobile"
+      id="welcome-desktop-title"
+    >
+      {{ $t("views.welcome.title") }}
+    </h1>
     <div class="Welcome__Description_Desktop" id="welcome-description-desktop">
       <div
         class="Welcome__Description_Desktop_Container"
         id="welcome-desktop-title-container"
       >
-        <h1
-          class="Welcome__Description_Desktop_Title"
-          id="welcome-desktop-title"
+        <span
+          class="Welcome__Description_Desktop_Title visually-hidden"
+          aria-hidden="true"
         >
           {{ $t("views.welcome.title") }}
-        </h1>
+        </span>
       </div>
 
       <div
@@ -80,9 +86,9 @@ const goToTracker = () => {
               id="welcome-tester-icon"
             />
             <div id="welcome-tester-card-content">
-              <h3 class="Welcome__Card_Title" id="welcome-tester-title">
+              <h2 class="Welcome__Card_Title" id="welcome-tester-title">
                 {{ $t("views.welcome.ballot_tester.title") }}
-              </h3>
+              </h2>
               <p
                 class="Welcome__Card_Description"
                 id="welcome-tester-description"
@@ -111,9 +117,9 @@ const goToTracker = () => {
               id="welcome-tracker-icon"
             />
             <div id="welcome-tracker-card-content">
-              <h3 class="Welcome__Card_Title" id="welcome-tracker-title">
+              <h2 class="Welcome__Card_Title" id="welcome-tracker-title">
                 {{ $t("views.welcome.ballot_tracker.title") }}
-              </h3>
+              </h2>
               <p
                 class="Welcome__Card_Description"
                 id="welcome-tracker-description"
@@ -136,9 +142,9 @@ const goToTracker = () => {
     </section>
 
     <section class="Welcome__About" id="welcome-about">
-      <h4 class="Welcome__About_Title" id="welcome-about-title">
+      <h2 class="Welcome__About_Title" id="welcome-about-title">
         {{ $t("views.welcome.about.title") }}
-      </h4>
+      </h2>
       <div
         class="Welcome__Card Welcome__Description"
         id="welcome-about-description"
@@ -152,12 +158,12 @@ const goToTracker = () => {
           class="Welcome__Card Welcome__Card_Overrides"
           id="welcome-about-tester-card"
         >
-          <h5
+          <h3
             class="Welcome__About_Subtitle"
             id="welcome-about-tester-subtitle"
           >
             {{ $t("views.welcome.about.ballot_tester") }}
-          </h5>
+          </h3>
           <p class="Welcome__About_Description" id="welcome-about-tester-text">
             {{ $t("views.welcome.about.ballot_tester_text") }}
           </p>
@@ -166,12 +172,12 @@ const goToTracker = () => {
           class="Welcome__Card Welcome__Card_Overrides"
           id="welcome-about-tracker-card"
         >
-          <h5
+          <h3
             class="Welcome__About_Subtitle"
             id="welcome-about-tracker-subtitle"
           >
             {{ $t("views.welcome.about.ballot_tracker") }}
-          </h5>
+          </h3>
           <p class="Welcome__About_Description" id="welcome-about-tracker-text">
             {{ $t("views.welcome.about.ballot_tracker_text") }}
           </p>
@@ -180,9 +186,9 @@ const goToTracker = () => {
           class="Welcome__Card Welcome__Card_Overrides"
           id="welcome-about-audit-card"
         >
-          <h5 class="Welcome__About_Subtitle" id="welcome-about-audit-subtitle">
+          <h3 class="Welcome__About_Subtitle" id="welcome-about-audit-subtitle">
             {{ $t("views.welcome.about.audit_log") }}
-          </h5>
+          </h3>
           <p class="Welcome__About_Description" id="welcome-about-audit-text">
             {{ $t("views.welcome.about.audit_log_text") }}
           </p>
@@ -201,6 +207,18 @@ const goToTracker = () => {
 </template>
 
 <style type="text/css" scoped>
+.visually-hidden-mobile {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .Welcome {
   height: calc(100dvh - 70px);
   width: 100%;
@@ -351,6 +369,17 @@ const goToTracker = () => {
 }
 
 @media only screen and (min-width: 80rem) {
+  .visually-hidden-mobile {
+    position: static;
+    width: auto;
+    height: auto;
+    padding: inherit;
+    margin: inherit;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+  }
+
   .Welcome__Description_Desktop {
     padding: 5rem;
     display: flex;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -42,10 +42,10 @@
     "@noble/hashes" "^1.8.0"
     sjcl-with-all "^1.0.8"
 
-"@assemblyvoting/electa-ui@5.6.5-beta.1":
-  version "5.6.5-beta.1"
-  resolved "https://registry.yarnpkg.com/@assemblyvoting/electa-ui/-/electa-ui-5.6.5-beta.1.tgz#a7b42d3a5ed9d2c161080eabc91433c1a972461a"
-  integrity sha512-vF2QFf3FxsI9XwsX2yuLN+WRCblWLGg4fouqjwZoLQiylFzhH6piZeRIQuVlPc1phgDnZ7jIybR+ud0md1wD2w==
+"@assemblyvoting/electa-ui@5.6.6-beta.2":
+  version "5.6.6-beta.2"
+  resolved "https://registry.yarnpkg.com/@assemblyvoting/electa-ui/-/electa-ui-5.6.6-beta.2.tgz#adc13d50e7ca3f9f0bd62b17bb7850e64f15fcc0"
+  integrity sha512-FSIhPLJVwKi6K9H4t3QrsVdk5ouoD0oG9/pw8Ts2WsNw7OesbsZQf2AEJDeIDsh0UfJNcmxPFC8GKOoKwAQfdg==
   dependencies:
     "@assemblyvoting/types" "^1.0.6"
     "@fontsource/open-sans" "^5.2.7"
@@ -61,10 +61,10 @@
     vue "^3.5.29"
     vue-i18n "^11.2.8"
 
-"@assemblyvoting/js-client@^6.1.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@assemblyvoting/js-client/-/js-client-6.2.0.tgz#287a3d5db1a4bbbc95242466698295c8e884d776"
-  integrity sha512-tBhdilIdE4OgIcacEy+odKHQR2SNyZ4hYRjtGqKDdbfqRP/lvAAgl3zyEL0pES2UEGjTyvf1NLCzeIOAITMo8w==
+"@assemblyvoting/js-client@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@assemblyvoting/js-client/-/js-client-6.3.0.tgz#2956944fa762c2d053ec1edd5f30b2efd35468cd"
+  integrity sha512-U9FLNvzgaMyqmRYCkvE+vWJh0C63U5CwRZT+2xZ9whHKIdw/w9Bm3+9XQ9Z5Hw8VsAFyEk1R6xwm8u0FVIAiSw==
   dependencies:
     "@assemblyvoting/av-crypto" "^1.1.1"
     axios "^1.13.6"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1350,6 +1350,11 @@ ansi-styles@^6.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
+aria-query@^5.0.0, aria-query@^5.3.0:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
+  integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
+
 assertion-error@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
@@ -1376,6 +1381,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axe-core@^4.4.2:
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.12.1.tgz#69fe2bf6dfc0b24973af91b1d8e945f79e1b7c44"
+  integrity sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==
 
 axe-core@~4.11.4:
   version "4.11.4"
@@ -1491,6 +1501,11 @@ chai@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
   integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
+
+chalk@^5.0.1:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
+  integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
 
 chokidar@^5.0.0:
   version "5.0.0"
@@ -1640,6 +1655,11 @@ diff@^8.0.3:
   resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.3.tgz#c7da3d9e0e8c283bb548681f8d7174653720c2d5"
   integrity sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==
 
+dom-accessibility-api@^0.5.14:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
+
 dompurify@^3.4.8:
   version "3.4.8"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.8.tgz#6c54f8c207160e7f83fcb7f4fd05a82ac36b1cdc"
@@ -1760,6 +1780,14 @@ eslint-plugin-vue@^10.9.2:
     postcss-selector-parser "^7.1.0"
     semver "^7.6.3"
     xml-name-validator "^4.0.0"
+
+eslint-plugin-vuejs-accessibility@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.5.0.tgz#532c3c7f3284b3504fe610cbd8a0177349054d36"
+  integrity sha512-oZ2fL4tS91Cm/ezH3BueNP+FtpbbeS627OSqqgp9/lsN//glmoPcLBT6D53xwGocLtyBybaT99tX4ThBh8+ytA==
+  dependencies:
+    aria-query "^5.3.0"
+    vue-eslint-parser "^9.0.0 || ^10.0.0"
 
 "eslint-scope@^8.2.0 || ^9.0.0":
   version "9.1.1"
@@ -2075,6 +2103,11 @@ glob@^10.4.2:
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
 
+globals@^17.6.0:
+  version "17.6.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-17.6.0.tgz#0f0be018d5cca8690e6375ead1f65c4bb96191fc"
+  integrity sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==
+
 gopd@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
@@ -2164,6 +2197,11 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
 ini@^1.3.4:
   version "1.3.8"
@@ -2399,6 +2437,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
+
 lodash@^4.17.21:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
@@ -2462,6 +2505,11 @@ mime-types@^2.1.12:
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 minimatch@9.0.1:
   version "9.0.1"
@@ -2813,6 +2861,14 @@ readdirp@^5.0.0:
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-5.0.0.tgz#fbf1f71a727891d685bb1786f9ba74084f6e2f91"
   integrity sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==
 
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
+
 require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
@@ -2997,6 +3053,13 @@ strip-ansi@^7.0.1:
   integrity sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==
   dependencies:
     ansi-regex "^6.0.1"
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 superjson@^2.2.2:
   version "2.2.6"
@@ -3207,6 +3270,18 @@ util-deprecate@^1.0.2:
   optionalDependencies:
     fsevents "~2.3.3"
 
+vitest-axe@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/vitest-axe/-/vitest-axe-0.1.0.tgz#34f714e5af31d579d7e2ca906d6b95207a1006ec"
+  integrity sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==
+  dependencies:
+    aria-query "^5.0.0"
+    axe-core "^4.4.2"
+    chalk "^5.0.1"
+    dom-accessibility-api "^0.5.14"
+    lodash-es "^4.17.21"
+    redent "^3.0.0"
+
 vitest@^4.1.8:
   version "4.1.8"
   resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.1.8.tgz#9fed17277bf7350497e54338898a7afd46dfd509"
@@ -3273,6 +3348,18 @@ vue-eslint-parser@^10.4.0:
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-10.4.0.tgz#fd7251d0e710a88a6618f50e8a27973bc3c8d69c"
   integrity sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==
+  dependencies:
+    debug "^4.4.0"
+    eslint-scope "^8.2.0 || ^9.0.0"
+    eslint-visitor-keys "^4.2.0 || ^5.0.0"
+    espree "^10.3.0 || ^11.0.0"
+    esquery "^1.6.0"
+    semver "^7.6.3"
+
+"vue-eslint-parser@^9.0.0 || ^10.0.0":
+  version "10.4.1"
+  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-10.4.1.tgz#3d0aabb6604dac3fcd94f893291cb9e754cc392c"
+  integrity sha512-Gk6gRDj0n/fkRa3C3l0bBheoBckUq/Rs0F/TvMWIS6nzzx67amAViMe9CkNgsP2tXyQONvGiHQESHwFtZ3aYDA==
   dependencies:
     debug "^4.4.0"
     eslint-scope "^8.2.0 || ^9.0.0"

--- a/doc/translation-keys.md
+++ b/doc/translation-keys.md
@@ -1,0 +1,524 @@
+# Translation Keys by Component/View
+
+This document provides a comprehensive list of all translation keys used in the Election Verification Site, organized by component and view.
+
+## Translation System Overview
+
+The project uses Vue I18n for internationalization with the following structure:
+- **Main translation file**: `client/src/assets/translations.ts`
+- **i18n configuration**: `client/src/lib/i18n.ts`
+- **Translation usage**: Components use `$t('key.path')` syntax
+- **Supported languages**: English (en), Spanish (es), German (de), Danish (da), and more
+
+## Global Translation Keys
+
+### Accessibility
+```typescript
+accessibility: {
+  skip_to_content: "Skip to main content",
+  help: "Help",
+  main_navigation: "Main navigation",
+  faq_navigation: "FAQ Navigation"
+}
+```
+
+### Header
+```typescript
+header: {
+  dbas: "Election Verification Site",
+  verification: "Ballot Tester",
+  tracking: "Ballot Tracker", 
+  logs: "Election Activity Log",
+  help: "FAQ",
+  contact: "Contact",
+  change_locale: {
+    en: "Switch to English",
+    es: "Cambiar a Español", 
+    da: "Skift til Dansk",
+    de: "Auf Deutsch umstellen"
+  },
+  election_logo_alt: "Election logo"
+}
+```
+
+### Footer
+```typescript
+footer: {
+  powered_by: "Powered by",
+  av_img_alt: "Lumi global logo"
+}
+```
+
+### Errors
+```typescript
+errors: {
+  go_to_verification: "Go to the verification site",
+  verify: {
+    invalid_code: {
+      title: "Testing code not found",
+      description: "Verify you have entered the testing code correctly..."
+    }
+  },
+  track: {
+    invalid_code: {
+      title: "Tracking code not found", 
+      description: "Verify you have entered the tracking code correctly..."
+    }
+  }
+}
+```
+
+---
+
+## Views Translation Keys
+
+### Welcome View (`Welcome.vue`)
+```typescript
+views.welcome: {
+  title: "Election Verification Site",
+  description: "This site provides overview of the election...",
+  splash_alt: "Election splash screen",
+  ballot_tester: {
+    title: "Test your ballot",
+    description: "I am voting and I want to check my choices",
+    button: "Test my ballot"
+  },
+  ballot_tracker: {
+    title: "Track your ballot", 
+    description: "I have voted and I want to track my ballot",
+    button: "Track my ballot"
+  },
+  about: {
+    title: "About this site",
+    ballot_tester: "Ballot Tester",
+    ballot_tester_text: "Use this tab to independently verify...",
+    ballot_tracker: "Ballot Tracker", 
+    ballot_tracker_text: "Voters can use this tab to verify...",
+    audit_log: "Audit Log",
+    audit_log_text: "Election audit log is a representation..."
+  }
+}
+```
+
+### Ballot Verification Landing (`BallotVerificationLanding.vue`)
+```typescript
+views.verification: {
+  title: "Ballot Tester",
+  subtitle: "I am voting and I want to",
+  subtitle_strong: "check my choices",
+  description: "You can check that your choices were recorded correctly...",
+  placeholder: "Testing Code",
+  button: "Start the Test",
+  tooltip_helper: "Where do I find the testing code",
+  tooltip_text: "Your testing code is displayed on the voting page.",
+  help: {
+    title: "How does the ",
+    title_strong: "test work?",
+    steps: {
+      step_1: "<strong>Input your testing code</strong> - Find it on the Voting Page",
+      step_2: "<strong>Passkeys</strong> get displayed in both...",
+      step_3: "On the voting page click on <strong>\"Does match\" or \"Does not match\"</strong>",
+      step_4: "<strong>Your choices are now shown</strong> in the Ballot Tester...",
+      step_5: "On the <strong>voting page click</strong> on \"Return to voting\"..."
+    },
+    footer: "All done!"
+  }
+}
+```
+
+### Ballot Verifier View (`BallotVerifierView.vue`)
+```typescript
+views.verifier: {
+  found: {
+    title: "Your ballot has been found!",
+    description: "Go back to the voting app and follow the instructions..."
+  },
+  inprogress: {
+    title: "Compare passkeys",
+    description: "Does this passkey match the one shown on the voting page?",
+    secondary_description: "Proceed to the voting page and check if the passkey is the same...",
+    help: {
+      title: "What's ",
+      title_strong: "next?",
+      p1: {
+        title: "Go back to the voting page",
+        description: "Click on Match / Do not Match button and follow instructions..."
+      }
+    },
+    modal: {
+      title: "Your session has expired due to inactivity",
+      description: "Please follow instructions on the voting page to restart...",
+      button: "Ok",
+      labelled_by: "Session expired"
+    }
+  },
+  spoiled: {
+    title: "Check the Choices",
+    description: "Your Ballot Choices",
+    info: "The choices connected to the testing code are displayed below...",
+    assigned: "Assigned: ",
+    ballot_selection: "Ballot Selection ",
+    finish: "Finish the test",
+    help: {
+      p1: {
+        title: "Go back to the voting page",
+        description: "Return to voting or abort the process."
+      }
+    }
+  },
+  blank_pile: "Blank"
+}
+```
+
+### Ballot Tracking Landing (`BallotTrackingLanding.vue`)
+```typescript
+views.tracking: {
+  title: "Ballot Tracker",
+  subtitle: "I have voted and I want to",
+  subtitle_strong: "track my ballot",
+  description: "To verify that your ballot was casted and recorded...",
+  placeholder: "Tracking code",
+  button: "Track my ballot",
+  tooltip_helper: "Where do I find my tracking code?",
+  tooltip_text: "Your ballot tracking code is displayed on the election page...",
+  help: {
+    title: "Make sure your vote counts in ",
+    title_strong: "2 easy steps",
+    steps: {
+      step_1: "<strong>Input your tracking code</strong> - Find it on the Voting Page",
+      step_2: "Check that <strong>your ballot is registered</strong> in the Digital Ballot Box..."
+    }
+  }
+}
+```
+
+### Ballot Tracker View (`BallotTrackerView.vue`)
+```typescript
+views.tracker: {
+  title: "Ballot Tracker",
+  info: {
+    title: "Ballot Registered",
+    description: "Your vote has been registered in digital ballot box.",
+    extended_description: "Below you can see all the activity attached to the code..."
+  },
+  help: {
+    title: "What's ",
+    title_strong: "next?",
+    p1: {
+      title: "Congratulations!",
+      text1: "You have tracked your ballot and helped to verify...",
+      text2: "Now you can sit back and wait until the election results are in."
+    },
+    p2: {
+      title: "Want to know more?",
+      text: "You can also read more about why this type of verification..."
+    }
+  }
+}
+```
+
+### Logs View (`LogsView.vue`)
+```typescript
+views.logs: {
+  title: "Election Activity Logs",
+  subtitle: "Public audit of the election",
+  description: "All election activities are listed in this election activity log...",
+  download_button: "Download the full election activity log (json)",
+  config_only: "Configuration items only",
+  hide_pending_items: "Hide pending",
+  headers: {
+    type: "Activity type",
+    type_tooltip: "Type of the activity recorded on Digital Ballot Box",
+    time: "Date and time",
+    actor: "Actor",
+    actor_tooltip: "Source of the activity type"
+  },
+  help: {
+    title: "What are the ",
+    title_strong: "logs for?",
+    p1: {
+      question: "What is an Election Activity log?",
+      answer: "The log is visual representation of the Digital Ballot Box..."
+    },
+    p2: {
+      question: "Why do we need one?",
+      answer: "Thanks to the log the integrity of the election can be verified..."
+    },
+    p3: {
+      question: "Who is the log for?",
+      answer: "For everyone who is interested. Primarily, the log is used by auditors..."
+    }
+  },
+  aria_labels: {
+    first_page: "Go to first page",
+    prev_page: "Previous page", 
+    next_page: "Next page",
+    last_page: "Go to last page"
+  }
+}
+```
+
+### Help/FAQ View (`HelpView.vue`)
+```typescript
+views.faq: {
+  title: "Frequently Asked Questions",
+  description: "Find answers to your questions and learn how the different parts...",
+  navigation: {
+    ballot_tester: "Ballot Tester",
+    ballot_tracker: "Ballot Tracker",
+    logs: "Election Logs",
+    other: "Other"
+  },
+  questions: {
+    ballot_tester: {
+      q1: {
+        title: "How does the Ballot Test work?",
+        paragraphs: {
+          p1: "The ballot test consists of 5 steps...",
+          p2: "The Steps are:",
+          p3: "1. Open ballot tester...",
+          // ... more paragraphs
+        }
+      },
+      // ... more questions q2-q8
+    },
+    ballot_tracker: {
+      q1: {
+        title: "How does the ballot tracking work?",
+        paragraphs: {
+          p1: "The ballot tracking is very simple...",
+          p2: "The tracking code is shown on the voting page..."
+        }
+      },
+      // ... more questions q2-q4
+    },
+    logs: {
+      q1: {
+        title: "What is an election activity log?",
+        paragraphs: {
+          p1: "As in physical voting, you have the ballot box...",
+          p2: "In the election activity log you can see all the activities..."
+        }
+      },
+      q2: {
+        title: "Who is the election log for?",
+        paragraphs: {
+          p1: "For anyone, who is interesting in looking through..."
+        }
+      }
+    },
+    other: {
+      q1: {
+        title: "Why is end-to-end verification important?",
+        paragraphs: {
+          p1: "Soon..."
+        }
+      },
+      // ... more questions q2-q6
+    }
+  },
+  help: {
+    title: "Why should I ",
+    title_strong: "test and track my ballot?",
+    p1: "By testing and tracking your ballot, you gain trust...",
+    p2: "By verifying that your ballot was encrypted with the right choices...",
+    p3: "Moreover, you also help to verify that the integrity..."
+  }
+}
+```
+
+---
+
+## Components Translation Keys
+
+### Header Component (`Header.vue`)
+```typescript
+header: {
+  dbas: "Election Verification Site",
+  verification: "Ballot Tester",
+  tracking: "Ballot Tracker",
+  logs: "Election Activity Log", 
+  help: "FAQ",
+  contact: "Contact",
+  election_logo_alt: "Election logo"
+}
+
+accessibility: {
+  main_navigation: "Main navigation"
+}
+```
+
+### Footer Component (`Footer.vue`)
+```typescript
+footer: {
+  powered_by: "Powered by",
+  av_img_alt: "Lumi global logo"
+}
+```
+
+### Content Layout Component (`ContentLayout.vue`)
+```typescript
+accessibility: {
+  help: "Help"
+}
+
+header: {
+  election_logo_alt: "Election logo"
+}
+```
+
+### Board Item Component (`BoardItem.vue`)
+```typescript
+components.board_item: {
+  registered_at: "Timestamp: ",
+  identifier: "Short Address: ",
+  author: "Actor: ",
+  meaning: "What does this mean?",
+  expand: "Click to read more",
+  collapse: "Click to read less",
+  aria_labels: {
+    activity_type: "Activity",
+    activity_registered: "Activity registered at",
+    activity_author: "Activity authored by", 
+    activity_identifier: "Activity identifier"
+  },
+  // ... BoardItem specific types (SegmentsConfigItem, SpoilRequestItem, etc.)
+}
+```
+
+### Ballot Activity Component (`BallotActivity.vue`)
+```typescript
+components.ballot_activity: {
+  registered_at: "Timestamp: ",
+  author: "Actor: ",
+  meaning: "What does this mean?",
+  // ... Activity specific types (AffidavitRejectItem, SpoilRequestItem, etc.)
+}
+
+components.board_item.aria_labels: {
+  activity_type: "Activity",
+  activity_registered: "Activity registered at",
+  activity_author: "Activity authored by"
+}
+```
+
+### Ballot Activity List Component (`BallotActivityList.vue`)
+```typescript
+components.ballot_activity_list: {
+  type: "Activity type",
+  type_tooltip: "Type of the activity recorded on Digital Ballot Box",
+  time: "Date and time",
+  actor: "Actor",
+  actor_tooltip: "Source of the activity type"
+}
+```
+
+### Tracked Ballot Manager Component (`TrackedBallotManager.vue`)
+```typescript
+components.tracked_ballot_manager: {
+  currently_tracking: "You are currently tracking",
+  cancel_cross_label: "Cancel tracking {trackingCode}"
+}
+```
+
+### Timedown Component (`Timedown.vue`)
+```typescript
+components.timedown: {
+  expire_text: "The passkey will expire in {time}",
+  alert: {
+    title: "You are running out of time.",
+    text: "Please confirm the passkeys match on the voting page..."
+  }
+}
+```
+
+### Drop Down Component (`DropDown.vue`)
+```typescript
+header.change_locale: {
+  label: "Change locale" // Note: This key might need to be added to translations
+}
+```
+
+---
+
+## Additional Translation Keys
+
+### Locales
+```typescript
+locales: {
+  en: "English",
+  de: "Deutsch", 
+  da: "Dansk",
+  es: "Español"
+}
+```
+
+### Offline Messages (Component Library)
+```typescript
+// These are used by the @assemblyvoting/electa-ui component library
+components: {
+  AVSpinner: {
+    loading: "Loading..."
+  }
+}
+
+accessibility: {
+  skip_to_content: "Skip to main content"
+}
+```
+
+---
+
+## Usage Patterns
+
+### In Vue Components
+```vue
+<!-- Basic usage -->
+{{ $t('views.welcome.title') }}
+
+<!-- With attributes -->
+:alt="$t('header.election_logo_alt')"
+
+<!-- With nested keys -->
+{{ $t('views.verifier.inprogress.help.title') }}
+
+<!-- With parameters -->
+{{ $t('components.timedown.expire_text', { time: '5 minutes' }) }}
+```
+
+### In TypeScript/JavaScript
+```typescript
+import i18n from '@/lib/i18n';
+
+// Access current locale
+const currentLocale = i18n.global.locale.value;
+
+// Change locale
+i18n.global.locale.value = 'es';
+```
+
+---
+
+## Notes for Translators
+
+1. **Key Structure**: Follow the pattern `category.component.property` for consistency
+2. **HTML Content**: Some translations contain HTML tags (e.g., `<strong>`) - preserve these in translations
+3. **Parameters**: Some keys accept parameters (e.g., `{time}`, `{trackingCode}`) - maintain these placeholders
+4. **Context**: Consider the context where each translation is used for accurate meaning
+5. **Consistency**: Use consistent terminology across related keys (e.g., "Ballot Tester", "Ballot Tracker")
+
+---
+
+## File Structure Reference
+
+```
+client/src/
+├── assets/
+│   └── translations.ts          # Main translation definitions
+├── lib/
+│   └── i18n.ts                 # i18n configuration
+├── components/                 # Vue components using translations
+└── views/                      # Vue views using translations
+```
+
+This document serves as a comprehensive reference for all translation keys in the Election Verification Site.


### PR DESCRIPTION
## Accessibility (a11y) — Testing with axe-core and ID attributes

### Summary

This branch adds automated accessibility testing with **axe-core** (via `vitest-axe` and Playwright) and applies accessibility and code quality improvements across the client.

### Main changes

#### Accessibility testing

* **E2E a11y tests** with Playwright + axe-core (`client/e2e/accessibility.spec.ts`): validates WCAG compliance across all views (Welcome, Ballot Verification, Ballot Tracker, Logs, Help, Receipt Error, etc.) on both desktop and mobile.
* **Unit a11y tests** with `vitest-axe` for individual components: `BallotActivity`, `BallotActivityList`, `BoardItem`, `ContentLayout`, `ExpandableSection`, `TrackedBallotManager`.
* Added `client/src/test-utils/a11y.ts` as a shared utility for unit a11y tests.
* Configured `eslint-plugin-vuejs-accessibility` to statically detect accessibility issues.

#### `id` attributes for testing and identification

* Added `id` attributes to all main components and views (`Header`, `Footer`, `ContentLayout`, `DropDown`, `Error`, `BallotActivity`, `BallotActivityList`, `BoardItem`, `BallotVerifierContest`, etc.) to make identification easier in E2E tests.

#### Accessibility improvements

* Fixed heading hierarchy (`h1` → `h2` → `h3`) across multiple views.
* Added `tabindex` to the help aside in `ContentLayout` to support keyboard navigation in Safari.
* Added dynamic IDs based on `index` in `BallotActivity` to avoid duplicate IDs.
* Fixed the `Error` component to generate IDs correctly.

#### Code quality and refactoring

* Refactored `eslint.config.js` to use `defineConfigWithVueTs`.
* Added a new `useElectionBranding` composable for centralized management of the document title, favicon, and brand styles.
* Added support for a **custom HTML footer** with sanitization via `DOMPurify`.
* Updated dependencies (`@assemblyvoting/types`, `@assemblyvoting/electa-ui`, etc.).
* Cleaned up `console.log` statements and applied consistent code formatting.

### Affected files

* **55 files** modified (+2,676 / −1,100 lines)
* New: `accessibility.spec.ts`, `*.a11y.test.ts`, `useElectionBranding.ts`, `a11y.ts`
