### PR TITLE
Don't install browsers on build but extract them from official image instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
   vm-linux-ubuntu:
     machine:
       image: ubuntu-2204:current
-      docker_layer_caching: true
+      docker_layer_caching: false
   vm-linux-ubuntu-nocache:
     machine:
       image: ubuntu-2204:current

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 
 RUN yarn build
 
-FROM mcr.microsoft.com/playwright:v1.60.0-noble AS development
+FROM mcr.microsoft.com/playwright:v1.61.0-noble AS development
 
 WORKDIR /usr/src/app
 COPY --from=builder /usr/src/app .

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -10,14 +10,15 @@ COPY . .
 
 RUN yarn build
 
-# We copy the already-extracted browsers from Microsoft's official image instead of running `npx playwright install`, whose download+extract step hangs on Apple Silicon. CI's e2e job needs these browsers in the development image.
-FROM mcr.microsoft.com/playwright:v1.58.2 AS playwright-browsers
-
+# Playwright browsers are required by CI's e2e job (`yarn test:e2e:ci`), which
+# runs on amd64. On amd64 we let Playwright install the exact browser revisions
+# matching the installed @playwright/test version. On arm64 (Apple Silicon /
+# Docker Desktop) the download+extract step hangs, and the local `evs` service
+# only runs `yarn dev`, so we skip it there. Install manually if you need to run
+# e2e locally:  npx playwright install --with-deps
 FROM builder AS development
-
-RUN npx playwright install-deps
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-COPY --from=playwright-browsers /ms-playwright /ms-playwright
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "amd64" ]; then npx playwright install --with-deps; fi
 
 FROM nginx:1.29-alpine AS production
 # Copy the built app only (Vite default output directory is "dist")

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:24-bullseye-slim AS builder
+FROM node:24.16-bullseye-slim AS builder
 
 WORKDIR /usr/src/app
 
@@ -15,7 +15,7 @@ FROM mcr.microsoft.com/playwright:v1.60.0-noble AS development
 WORKDIR /usr/src/app
 COPY --from=builder /usr/src/app .
 
-FROM nginx:1.29-alpine AS production
+FROM nginx:1.31-alpine AS production
 # Copy the built app only (Vite default output directory is "dist")
 COPY --from=builder /usr/src/app/dist /usr/share/nginx/html
 ENV VITE_DBB_URL=""

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -10,9 +10,14 @@ COPY . .
 
 RUN yarn build
 
+# We copy the already-extracted browsers from Microsoft's official image instead of running `npx playwright install`, whose download+extract step hangs on Apple Silicon. CI's e2e job needs these browsers in the development image.
+FROM mcr.microsoft.com/playwright:v1.58.2 AS playwright-browsers
+
 FROM builder AS development
 
-RUN npx playwright install --with-deps
+RUN npx playwright install-deps
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+COPY --from=playwright-browsers /ms-playwright /ms-playwright
 
 FROM nginx:1.29-alpine AS production
 # Copy the built app only (Vite default output directory is "dist")

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -10,15 +10,10 @@ COPY . .
 
 RUN yarn build
 
-# Playwright browsers are required by CI's e2e job (`yarn test:e2e:ci`), which
-# runs on amd64. On amd64 we let Playwright install the exact browser revisions
-# matching the installed @playwright/test version. On arm64 (Apple Silicon /
-# Docker Desktop) the download+extract step hangs, and the local `evs` service
-# only runs `yarn dev`, so we skip it there. Install manually if you need to run
-# e2e locally:  npx playwright install --with-deps
-FROM builder AS development
-ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "amd64" ]; then npx playwright install --with-deps; fi
+FROM mcr.microsoft.com/playwright:v1.60.0-noble AS development
+
+WORKDIR /usr/src/app
+COPY --from=builder /usr/src/app .
 
 FROM nginx:1.29-alpine AS production
 # Copy the built app only (Vite default output directory is "dist")

--- a/client/package.json
+++ b/client/package.json
@@ -40,7 +40,7 @@
     "@assemblyvoting/types": "^1.0.0",
     "@axe-core/playwright": "^4.10.1",
     "@pinia/testing": "^1.0.3",
-    "@playwright/test": "^1.49.1",
+    "@playwright/test": "^1.61.0",
     "@rushstack/eslint-patch": "^1.10.5",
     "@types/jsdom": "^28.0.0",
     "@types/node": "^24.10.15",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -642,12 +642,12 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@playwright/test@^1.49.1":
-  version "1.58.2"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.58.2.tgz#b0ad585d2e950d690ef52424967a42f40c6d2cbd"
-  integrity sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==
+"@playwright/test@^1.61.0":
+  version "1.61.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.61.0.tgz#dcc3d43e581aab2985d70413309d89350e980ad8"
+  integrity sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==
   dependencies:
-    playwright "1.58.2"
+    playwright "1.61.0"
 
 "@popperjs/core@^2.11.8":
   version "2.11.8"
@@ -2568,17 +2568,17 @@ pkg-types@^2.3.0:
     exsolve "^1.0.7"
     pathe "^2.0.3"
 
-playwright-core@1.58.2:
-  version "1.58.2"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.58.2.tgz#ac5f5b4b10d29bcf934415f0b8d133b34b0dcb13"
-  integrity sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==
+playwright-core@1.61.0:
+  version "1.61.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.61.0.tgz#caf8078b2a39cd7738dc75ec11cb3b47f385c3f0"
+  integrity sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==
 
-playwright@1.58.2:
-  version "1.58.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.58.2.tgz#afe547164539b0bcfcb79957394a7a3fa8683cfd"
-  integrity sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==
+playwright@1.61.0:
+  version "1.61.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.61.0.tgz#7082df3df08ffa82b11420ea5fae84a40bd16e3f"
+  integrity sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==
   dependencies:
-    playwright-core "1.58.2"
+    playwright-core "1.61.0"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
**Problem**
Building the election-verification-site client image (development target, used by the devbox evs service) consistently appeared to freeze. The build log showed RUN npx playwright install --with-deps reaching 100% of 179.6 MiB and then sitting there for ~16 minutes with no further output.

**Root cause**
The browser download completes in ~6 seconds and reaches 100%.
The hang happens after download, during the silent extraction of the browser archive (chromium-linux-arm64.zip). On Apple Silicon + Docker Desktop's virtual filesystem, extracting ~180 MB of many small files into the build's overlay is extremely slow.
BuildKit collapses progress to the last line, so the completed download bar stays on screen the whole time, making it look frozen.
Because the step also ran after COPY . ., it re-ran on every source change.

**Changes**
client/Dockerfile: add playwright-browsers stage, copy browsers into development, set PLAYWRIGHT_BROWSERS_PATH, drop npx playwright install.

**Maintenance**
The image tag is pinned to the Playwright version. When bumping @playwright/test, update mcr.microsoft.com/playwright:vX.Y.Z in the Dockerfile to match, otherwise Playwright won't find the matching browser revision.