### PR TITLE
Remove CVE-2026-22184 Trivy suppression (patched in nginx:1.31-alpine)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,8 +211,6 @@ jobs:
             docker pull ${ECR_REGISTRY_ID}.dkr.ecr.eu-west-1.amazonaws.com/election-verification-site:${CIRCLE_SHA1}-untested
       - docker/scan:
           image: ${ECR_REGISTRY_ID}.dkr.ecr.eu-west-1.amazonaws.com/election-verification-site:${CIRCLE_SHA1}-untested
-          # CVE-2026-22184 we cannot fix this until there's a new version of the nginx:alpine image we're currently using.
-          ignored_cves: 'CVE-2026-22184'
   client-e2e:
     executor: vm-linux-ubuntu-nocache
     steps:


### PR DESCRIPTION
AB#2926

## Summary

Remove the `ignored_cves: 'CVE-2026-22184'` suppression from the Trivy scan step in CircleCI. The CVE is no longer present in the current production image (`nginx:1.31-alpine`), so the exception is no longer needed and the scanner now runs without overrides.

## Verification

Local Trivy scan run against both images before removing the suppression:

| Image | nginx | Alpine | CVE-2026-22184 | HIGH/CRITICAL total |
|---|---|---|---|---|
| `nginx:1.29-alpine` (previous) | 1.29.8 | 3.23.4 | not present | 5 HIGH (unrelated CVEs) |
| `nginx:1.31-alpine` (current) | 1.31.2 | 3.23.5 | not present | **0** |

## Changes

- `.circleci/config.yml` — removed `ignored_cves: 'CVE-2026-22184'` and its associated comment from the `scan-client` job.
