### PR TITLE
Remove unnecessary chown command from Dockerfile

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -35,8 +35,6 @@ RUN chmod +x /docker-entrypoint.d/40-write-env-js.sh
 
 COPY nginx.conf /etc/nginx/nginx.conf
 
-RUN chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /var/run
-
 EXPOSE 8080
 USER nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -36,5 +36,4 @@ RUN chmod +x /docker-entrypoint.d/40-write-env-js.sh
 COPY nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 8080
-USER nginx
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
The chown operation is redundant as the nginx:1.31-alpine base image already sets appropriate ownership for these directories.