### PR TITLE
Add results view, accessibility improvements, and election branding

### DIFF
--- a/client/.husky/pre-commit
+++ b/client/.husky/pre-commit
@@ -1,0 +1,1 @@
+cd client && yarn --ignore-engines lint-staged

--- a/client/e2e/results.spec.ts
+++ b/client/e2e/results.spec.ts
@@ -68,7 +68,7 @@ function setupRoutes(
       return route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify(options.resultsPublished),
+        body: JSON.stringify({ resultsPublished: options.resultsPublished }),
       });
     }
 

--- a/client/e2e/results.spec.ts
+++ b/client/e2e/results.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from "@playwright/test";
+import analyzeAccessibility from "./accessibility";
+import { latestConfig, status } from "./mocks";
+
+const translations = {
+  translations: {
+    en: {
+      js: {
+        election_verification_site: {},
+        components: {},
+        accessibility: {},
+      },
+    },
+    es: {
+      js: {
+        election_verification_site: {},
+        components: {},
+        accessibility: {},
+      },
+    },
+  },
+};
+
+const publishedResults = [
+  {
+    votingRoundName: "Round A",
+    votingRoundClosingDate: "2025-01-10T00:00:00.000Z",
+    publishedAt: "2025-01-15T10:00:00.000Z",
+    pdf: btoa("%PDF-1.4 fake content A"),
+  },
+  {
+    votingRoundName: "Round B",
+    votingRoundClosingDate: "2025-03-15T00:00:00.000Z",
+    publishedAt: "2025-03-20T10:00:00.000Z",
+    pdf: btoa("%PDF-1.4 fake content B"),
+  },
+];
+
+function setupRoutes(
+  page: import("@playwright/test").Page,
+  options: {
+    resultsPublished: boolean;
+    publishedResults?: typeof publishedResults;
+  },
+) {
+  return page.route("**/*", async (route) => {
+    const url = route.request().url();
+    const isConference = url.includes("electa.localhost");
+    const isDBB = url.includes("dbb.localhost");
+
+    if (isDBB && url.includes("latest_config")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(latestConfig),
+      });
+    }
+
+    if (isConference && url.includes("/status")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(status),
+      });
+    }
+
+    if (isConference && url.includes("/results_published")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(options.resultsPublished),
+      });
+    }
+
+    if (
+      isConference &&
+      url.includes("/published_results") &&
+      options.publishedResults
+    ) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(options.publishedResults),
+      });
+    }
+
+    if (isConference && url.includes("/translations")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(translations),
+      });
+    }
+
+    if (isConference && url.includes("/theme")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "text/css",
+        body: "",
+      });
+    }
+
+    return route.continue();
+  });
+}
+
+test("viewing published results", async ({ page, isMobile }) => {
+  await setupRoutes(page, {
+    resultsPublished: true,
+    publishedResults,
+  });
+
+  await page.goto("/en/organisation_slug/election_slug");
+  if (isMobile) {
+    await page.locator(".Header__Hamburger_Btn").click();
+  }
+  await page.getByRole("link", { name: "Results" }).waitFor();
+  await analyzeAccessibility(page);
+  if (isMobile) {
+    await analyzeAccessibility(page);
+  }
+
+  const resultsLink = page.getByRole("link", { name: "Results" });
+  await expect(resultsLink).toBeVisible();
+  await resultsLink.click();
+  await analyzeAccessibility(page);
+
+  await expect(page.locator("#result-card-title")).toHaveCount(2);
+  await expect(page.locator("#result-card-title").first()).toHaveText(
+    "Round A",
+  );
+  await expect(page.locator("#result-card-title").nth(1)).toHaveText("Round B");
+
+  await expect(page.locator("#result-card-pdf-object")).toHaveCount(2);
+  await expect(page.locator("#result-card-download")).toHaveCount(2);
+});
+
+test("results menu hidden when no results published", async ({ page }) => {
+  await setupRoutes(page, { resultsPublished: false });
+
+  await page.goto("/en/organisation_slug/election_slug");
+
+  await expect(page.getByRole("link", { name: "Results" })).not.toBeVisible();
+});

--- a/client/e2e/results.spec.ts
+++ b/client/e2e/results.spec.ts
@@ -125,14 +125,14 @@ test("viewing published results", async ({ page, isMobile }) => {
   await resultsLink.click();
   await analyzeAccessibility(page);
 
-  await expect(page.locator("#result-card-title")).toHaveCount(2);
-  await expect(page.locator("#result-card-title").first()).toHaveText(
+  await expect(page.locator('[data-testid="result-card-title"]')).toHaveCount(2);
+  await expect(page.locator('[data-testid="result-card-title"]').first()).toHaveText(
     "Round A",
   );
-  await expect(page.locator("#result-card-title").nth(1)).toHaveText("Round B");
+  await expect(page.locator('[data-testid="result-card-title"]').nth(1)).toHaveText("Round B");
 
-  await expect(page.locator("#result-card-pdf-object")).toHaveCount(2);
-  await expect(page.locator("#result-card-download")).toHaveCount(2);
+  await expect(page.locator('[data-testid="result-card-pdf-object"]')).toHaveCount(2);
+  await expect(page.locator('[data-testid="result-card-download"]')).toHaveCount(2);
 });
 
 test("results menu hidden when no results published", async ({ page }) => {

--- a/client/e2e/results.spec.ts
+++ b/client/e2e/results.spec.ts
@@ -125,14 +125,22 @@ test("viewing published results", async ({ page, isMobile }) => {
   await resultsLink.click();
   await analyzeAccessibility(page);
 
-  await expect(page.locator('[data-testid="result-card-title"]')).toHaveCount(2);
-  await expect(page.locator('[data-testid="result-card-title"]').first()).toHaveText(
-    "Round A",
+  await expect(page.locator('[data-testid="result-card-title"]')).toHaveCount(
+    2,
   );
-  await expect(page.locator('[data-testid="result-card-title"]').nth(1)).toHaveText("Round B");
+  await expect(
+    page.locator('[data-testid="result-card-title"]').first(),
+  ).toHaveText("Round A");
+  await expect(
+    page.locator('[data-testid="result-card-title"]').nth(1),
+  ).toHaveText("Round B");
 
-  await expect(page.locator('[data-testid="result-card-pdf-object"]')).toHaveCount(2);
-  await expect(page.locator('[data-testid="result-card-download"]')).toHaveCount(2);
+  await expect(
+    page.locator('[data-testid="result-card-pdf-object"]'),
+  ).toHaveCount(2);
+  await expect(
+    page.locator('[data-testid="result-card-download"]'),
+  ).toHaveCount(2);
 });
 
 test("results menu hidden when no results published", async ({ page }) => {

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,11 @@
     "prettier:ci": "npx prettier -c ./",
     "prettier": "npx prettier -w ./",
     "lint": "eslint ./src/**/*.{ts,mts,tsx,vue} --fix",
-    "lint:ci": "eslint ./src/**/*.{ts,mts,tsx,vue}"
+    "lint:ci": "eslint ./src/**/*.{ts,mts,tsx,vue}",
+    "prepare": "cd .. && husky client/.husky"
+  },
+  "lint-staged": {
+    "*.{ts,mts,tsx,vue,js,jsx,json,css,scss,md,html,yml,yaml}": "prettier --write"
   },
   "dependencies": {
     "@assemblyvoting/electa-ui": "5.7.2-ontario",
@@ -58,6 +62,8 @@
     "prettier": "^3.8.3",
     "typescript": "^5.4.5",
     "vite": "^8.1.3",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.5.2",
     "vitest": "^4.1.8",
     "vitest-axe": "^0.1.0"
   },

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -60,6 +60,15 @@ const setConfigurations = async (
 
   configStore.setBoardSlug((await conferenceClient.getStatus()).boardSlug);
 
+  try {
+    configStore.setResultsPublished(
+      await conferenceClient.getResultsPublished(),
+    );
+  } catch (err) {
+    console.error(err);
+    configStore.setResultsPublished(false);
+  }
+
   await configStore.loadConfig();
   await setLanguage(conferenceClient);
   await setTheme(conferenceClient);

--- a/client/src/Types.ts
+++ b/client/src/Types.ts
@@ -57,8 +57,15 @@ export interface ExtendedElectionStatusResponse extends ElectionStatusResponse {
 }
 
 export interface CustomCosmetics {
-  hideElectionClientFooter?: boolean;
+  hideElectionCommitteeFooter?: boolean;
   useWideScrollbar?: boolean;
   votingSteps?: any;
   footerHtml?: string | Record<string, string>;
+}
+
+export interface PublishedResult {
+  votingRoundName: string;
+  votingRoundClosingDate: string | null;
+  publishedAt: string;
+  pdf: string;
 }

--- a/client/src/assets/translations.ts
+++ b/client/src/assets/translations.ts
@@ -237,6 +237,7 @@ export const fallbackMessages: SpreadableDLM = {
       verification: "Ballot Tester",
       tracking: "Ballot Tracker",
       logs: "Election Activity Log",
+      results: "Results",
       help: "FAQ",
       contact: "Contact",
       change_locale: {
@@ -638,6 +639,29 @@ export const fallbackMessages: SpreadableDLM = {
           last_page: "Go to last page",
         },
       },
+      results: {
+        title: "Election Results",
+        description:
+          "The published results of the election's voting rounds are available below. You can preview and download the result PDF for each voting round.",
+        published_on: "Published on",
+        download: "Download PDF",
+        preview_unavailable:
+          "Your browser cannot display the PDF preview. You can download it using the link below.",
+        empty_state:
+          "No results have been published yet. Please check back later.",
+        error_state:
+          "An error occurred while loading the results. Please try again.",
+        retry: "Retry",
+        help: {
+          title: "What are the ",
+          title_strong: "results?",
+          p1: {
+            question: "What are the election results?",
+            answer:
+              "The election results show the official outcome of each voting round. Once a voting round is closed and the results are published, they are displayed here for public review.",
+          },
+        },
+      },
       faq: {
         title: "Frequently Asked Questions",
         description:
@@ -814,6 +838,7 @@ export const fallbackMessages: SpreadableDLM = {
       verification: "Testeo de Boleta",
       tracking: "Seguimiento de Boleta",
       logs: "Registro de la elección",
+      results: "Resultados",
       help: "Preguntas Frecuentes",
       contact: "Contacto",
       change_locale: {

--- a/client/src/components/Footer.vue
+++ b/client/src/components/Footer.vue
@@ -34,7 +34,11 @@ const customFooterHtml = computed(() => {
   const template = document.createElement("template");
   template.innerHTML = sanitized;
   template.content.querySelectorAll("a[target='_blank']").forEach((a) => {
-    a.setAttribute("rel", "noopener noreferrer");
+    const existingRel = a.getAttribute("rel");
+    const tokens = existingRel ? existingRel.split(/\s+/).filter(Boolean) : [];
+    if (!tokens.includes("noopener")) tokens.push("noopener");
+    if (!tokens.includes("noreferrer")) tokens.push("noreferrer");
+    a.setAttribute("rel", tokens.join(" "));
   });
   return template.innerHTML;
 });

--- a/client/src/components/Header.vue
+++ b/client/src/components/Header.vue
@@ -130,6 +130,17 @@ onBeforeUnmount(() => {
       </RouterLink>
 
       <RouterLink
+        v-if="configStore.resultsPublished"
+        class="Header__Link"
+        activeClass="active"
+        :to="`/${locale}/${route.params.organisationSlug}/${route.params.electionSlug}/results`"
+        @click="toggleMenu(true)"
+        id="header-link-results"
+      >
+        {{ $t("header.results") }}
+      </RouterLink>
+
+      <RouterLink
         class="Header__Link"
         activeClass="active"
         :to="`/${locale}/${route.params.organisationSlug}/${route.params.electionSlug}/help`"

--- a/client/src/components/ResultCard.a11y.test.ts
+++ b/client/src/components/ResultCard.a11y.test.ts
@@ -1,0 +1,33 @@
+import "../test-utils/setupConfig";
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { axe } from "vitest-axe";
+import ResultCard from "./ResultCard.vue";
+import { mountForA11y } from "../test-utils/a11y";
+import type { PublishedResult } from "@/Types";
+
+vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:fake-url");
+vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+
+const mockResult: PublishedResult = {
+  votingRoundName: "Round 1 - General Election",
+  votingRoundClosingDate: "2025-01-15T00:00:00.000Z",
+  publishedAt: "2025-01-20T10:30:00.000Z",
+  pdf: btoa("%PDF-1.4 fake pdf content"),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+test("ResultCard has no accessibility violations", async () => {
+  const wrapper = await mountForA11y(ResultCard, {
+    props: { result: mockResult },
+  });
+  const results = await axe(wrapper.element);
+  await expect(results).toHaveNoViolations();
+  wrapper.unmount();
+});

--- a/client/src/components/ResultCard.test.ts
+++ b/client/src/components/ResultCard.test.ts
@@ -1,0 +1,106 @@
+import "../test-utils/setupConfig";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createI18n } from "vue-i18n";
+import { createPinia } from "pinia";
+import ResultCard from "./ResultCard.vue";
+import type { PublishedResult } from "@/Types";
+import { fallbackMessages } from "../assets/translations";
+
+const neededStrings = JSON.stringify(fallbackMessages.en);
+const messages = { en: JSON.parse(neededStrings) };
+const i18n = createI18n({ messages });
+
+vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:fake-url");
+const revokeSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+
+const mockResult: PublishedResult = {
+  votingRoundName: "Round 1 - General Election",
+  votingRoundClosingDate: "2025-01-15T00:00:00.000Z",
+  publishedAt: "2025-01-20T10:30:00.000Z",
+  pdf: btoa("%PDF-1.4 fake pdf content"),
+};
+
+describe("ResultCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the voting round name as a heading", () => {
+    const wrapper = mount(ResultCard, {
+      props: { result: mockResult },
+      global: { plugins: [i18n, createPinia()] },
+    });
+
+    expect(wrapper.find("#result-card-title").text()).toBe(
+      "Round 1 - General Election",
+    );
+    wrapper.unmount();
+  });
+
+  it("renders the published_at date", () => {
+    const wrapper = mount(ResultCard, {
+      props: { result: mockResult },
+      global: { plugins: [i18n, createPinia()] },
+    });
+
+    const timeElement = wrapper.find("time");
+    expect(timeElement.exists()).toBe(true);
+    expect(timeElement.attributes("datetime")).toBe("2025-01-20T10:30:00.000Z");
+    wrapper.unmount();
+  });
+
+  it("renders an object element for PDF preview", () => {
+    const wrapper = mount(ResultCard, {
+      props: { result: mockResult },
+      global: { plugins: [i18n, createPinia()] },
+    });
+
+    const objectEl = wrapper.find("#result-card-pdf-object");
+    expect(objectEl.exists()).toBe(true);
+    expect(objectEl.attributes("type")).toBe("application/pdf");
+    expect(objectEl.attributes("data")).toBe("blob:fake-url");
+    wrapper.unmount();
+  });
+
+  it("renders a download link", () => {
+    const wrapper = mount(ResultCard, {
+      props: { result: mockResult },
+      global: { plugins: [i18n, createPinia()] },
+    });
+
+    const downloadLink = wrapper.find("#result-card-download");
+    expect(downloadLink.exists()).toBe(true);
+    expect(downloadLink.attributes("href")).toBe("blob:fake-url");
+    expect(downloadLink.attributes("download")).toBe(
+      "Round 1 - General Election.pdf",
+    );
+    wrapper.unmount();
+  });
+
+  it("renders a fallback download link inside the object element", () => {
+    const wrapper = mount(ResultCard, {
+      props: { result: mockResult },
+      global: { plugins: [i18n, createPinia()] },
+    });
+
+    const fallbackLink = wrapper.find("#result-card-fallback-download");
+    expect(fallbackLink.exists()).toBe(true);
+    expect(fallbackLink.attributes("href")).toBe("blob:fake-url");
+    wrapper.unmount();
+  });
+
+  it("revokes the object URL on unmount", () => {
+    const wrapper = mount(ResultCard, {
+      props: { result: mockResult },
+      global: { plugins: [i18n, createPinia()] },
+    });
+
+    wrapper.unmount();
+    expect(revokeSpy).toHaveBeenCalledWith("blob:fake-url");
+  });
+});

--- a/client/src/components/ResultCard.test.ts
+++ b/client/src/components/ResultCard.test.ts
@@ -36,7 +36,7 @@ describe("ResultCard", () => {
       global: { plugins: [i18n, createPinia()] },
     });
 
-    expect(wrapper.find("#result-card-title").text()).toBe(
+    expect(wrapper.find('[data-testid="result-card-title"]').text()).toBe(
       "Round 1 - General Election",
     );
     wrapper.unmount();
@@ -60,7 +60,7 @@ describe("ResultCard", () => {
       global: { plugins: [i18n, createPinia()] },
     });
 
-    const objectEl = wrapper.find("#result-card-pdf-object");
+    const objectEl = wrapper.find('[data-testid="result-card-pdf-object"]');
     expect(objectEl.exists()).toBe(true);
     expect(objectEl.attributes("type")).toBe("application/pdf");
     expect(objectEl.attributes("data")).toBe("blob:fake-url");
@@ -73,7 +73,7 @@ describe("ResultCard", () => {
       global: { plugins: [i18n, createPinia()] },
     });
 
-    const downloadLink = wrapper.find("#result-card-download");
+    const downloadLink = wrapper.find('[data-testid="result-card-download"]');
     expect(downloadLink.exists()).toBe(true);
     expect(downloadLink.attributes("href")).toBe("blob:fake-url");
     expect(downloadLink.attributes("download")).toBe(
@@ -88,7 +88,7 @@ describe("ResultCard", () => {
       global: { plugins: [i18n, createPinia()] },
     });
 
-    const fallbackLink = wrapper.find("#result-card-fallback-download");
+    const fallbackLink = wrapper.find('[data-testid="result-card-fallback-download"]');
     expect(fallbackLink.exists()).toBe(true);
     expect(fallbackLink.attributes("href")).toBe("blob:fake-url");
     wrapper.unmount();

--- a/client/src/components/ResultCard.test.ts
+++ b/client/src/components/ResultCard.test.ts
@@ -88,7 +88,9 @@ describe("ResultCard", () => {
       global: { plugins: [i18n, createPinia()] },
     });
 
-    const fallbackLink = wrapper.find('[data-testid="result-card-fallback-download"]');
+    const fallbackLink = wrapper.find(
+      '[data-testid="result-card-fallback-download"]',
+    );
     expect(fallbackLink.exists()).toBe(true);
     expect(fallbackLink.attributes("href")).toBe("blob:fake-url");
     wrapper.unmount();

--- a/client/src/components/ResultCard.vue
+++ b/client/src/components/ResultCard.vue
@@ -25,9 +25,7 @@ const formattedDate = computed(() => {
   }
 });
 
-const downloadFileName = computed(
-  () => `${source.value.votingRoundName}.pdf`,
-);
+const downloadFileName = computed(() => `${source.value.votingRoundName}.pdf`);
 </script>
 
 <template>

--- a/client/src/components/ResultCard.vue
+++ b/client/src/components/ResultCard.vue
@@ -29,12 +29,12 @@ const downloadFileName = computed(() => `${source.value.votingRoundName}.pdf`);
 </script>
 
 <template>
-  <article class="ResultCard" id="result-card">
+  <article class="ResultCard" data-testid="result-card">
     <header class="ResultCard__Header">
-      <h2 class="ResultCard__Title" id="result-card-title">
+      <h2 class="ResultCard__Title" data-testid="result-card-title">
         {{ result.votingRoundName }}
       </h2>
-      <p class="ResultCard__Date" id="result-card-date">
+      <p class="ResultCard__Date" data-testid="result-card-date">
         <span class="ResultCard__Date_Label">{{
           $t("views.results.published_on")
         }}</span>
@@ -42,24 +42,24 @@ const downloadFileName = computed(() => `${source.value.votingRoundName}.pdf`);
       </p>
     </header>
 
-    <div class="ResultCard__Preview" id="result-card-preview">
+    <div class="ResultCard__Preview" data-testid="result-card-preview">
       <object
         v-if="blobUrl"
         :data="blobUrl"
         type="application/pdf"
         class="ResultCard__Object"
-        id="result-card-pdf-object"
+        data-testid="result-card-pdf-object"
         :title="$t('views.results.preview_unavailable')"
         :aria-label="result.votingRoundName"
       >
-        <p class="ResultCard__Fallback" id="result-card-fallback">
+        <p class="ResultCard__Fallback" data-testid="result-card-fallback">
           {{ $t("views.results.preview_unavailable") }}
         </p>
         <a
           :href="blobUrl"
           :download="downloadFileName"
           class="ResultCard__DownloadLink ResultCard__DownloadLink--fallback"
-          id="result-card-fallback-download"
+          data-testid="result-card-fallback-download"
         >
           <AVIcon icon="download" aria-hidden="true" />
           {{ $t("views.results.download") }}
@@ -72,7 +72,7 @@ const downloadFileName = computed(() => `${source.value.votingRoundName}.pdf`);
       :href="blobUrl"
       :download="downloadFileName"
       class="ResultCard__DownloadLink"
-      id="result-card-download"
+      data-testid="result-card-download"
     >
       <AVIcon icon="download" aria-hidden="true" />
       {{ $t("views.results.download") }}

--- a/client/src/components/ResultCard.vue
+++ b/client/src/components/ResultCard.vue
@@ -1,0 +1,186 @@
+<script setup lang="ts">
+import { computed, toRef } from "vue";
+import { useI18n } from "vue-i18n";
+import type { PublishedResult } from "@/Types";
+import { usePdfPreview } from "@/composables/usePdfPreview";
+
+const props = defineProps<{
+  result: PublishedResult;
+}>();
+
+const { locale } = useI18n();
+const source = toRef(props, "result");
+
+const pdfBase64 = computed(() => source.value.pdf);
+const { blobUrl } = usePdfPreview(pdfBase64);
+
+const formattedDate = computed(() => {
+  try {
+    return new Intl.DateTimeFormat(locale.value, {
+      dateStyle: "long",
+      timeStyle: "short",
+    }).format(new Date(source.value.publishedAt));
+  } catch {
+    return source.value.publishedAt;
+  }
+});
+
+const downloadFileName = computed(
+  () => `${source.value.votingRoundName}.pdf`,
+);
+</script>
+
+<template>
+  <article class="ResultCard" id="result-card">
+    <header class="ResultCard__Header">
+      <h2 class="ResultCard__Title" id="result-card-title">
+        {{ result.votingRoundName }}
+      </h2>
+      <p class="ResultCard__Date" id="result-card-date">
+        <span class="ResultCard__Date_Label">{{
+          $t("views.results.published_on")
+        }}</span>
+        <time :datetime="result.publishedAt">{{ formattedDate }}</time>
+      </p>
+    </header>
+
+    <div class="ResultCard__Preview" id="result-card-preview">
+      <object
+        v-if="blobUrl"
+        :data="blobUrl"
+        type="application/pdf"
+        class="ResultCard__Object"
+        id="result-card-pdf-object"
+        :title="$t('views.results.preview_unavailable')"
+        :aria-label="result.votingRoundName"
+      >
+        <p class="ResultCard__Fallback" id="result-card-fallback">
+          {{ $t("views.results.preview_unavailable") }}
+        </p>
+        <a
+          :href="blobUrl"
+          :download="downloadFileName"
+          class="ResultCard__DownloadLink ResultCard__DownloadLink--fallback"
+          id="result-card-fallback-download"
+        >
+          <AVIcon icon="download" aria-hidden="true" />
+          {{ $t("views.results.download") }}
+        </a>
+      </object>
+    </div>
+
+    <a
+      v-if="blobUrl"
+      :href="blobUrl"
+      :download="downloadFileName"
+      class="ResultCard__DownloadLink"
+      id="result-card-download"
+    >
+      <AVIcon icon="download" aria-hidden="true" />
+      {{ $t("views.results.download") }}
+    </a>
+  </article>
+</template>
+
+<style scoped>
+.ResultCard {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-bottom: 2rem;
+  padding: 1.5rem;
+  border: 1px solid var(--bs-gray-300);
+  border-radius: 12px;
+  background-color: var(--bs-white);
+}
+
+.ResultCard__Header {
+  margin-bottom: 1rem;
+}
+
+.ResultCard__Title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--bs-gray-800);
+  margin: 0 0 0.5rem 0;
+}
+
+.ResultCard__Date {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+  color: var(--bs-gray-600);
+  margin: 0;
+}
+
+.ResultCard__Date_Label {
+  font-weight: 600;
+}
+
+.ResultCard__Preview {
+  width: 100%;
+  min-height: 30rem;
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: var(--bs-gray-100);
+}
+
+.ResultCard__Object {
+  width: 100%;
+  height: 30rem;
+  border: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.ResultCard__Fallback {
+  color: var(--bs-gray-700);
+  text-align: center;
+  margin: 0;
+  padding: 1rem;
+}
+
+.ResultCard__DownloadLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  align-self: flex-start;
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--bs-white);
+  background-color: var(--av-theme-background);
+}
+
+.ResultCard__DownloadLink:hover {
+  opacity: 0.9;
+}
+
+.ResultCard__DownloadLink--fallback {
+  background-color: var(--bs-gray-700);
+}
+
+@media only screen and (min-width: 48rem) {
+  .ResultCard {
+    padding: 2rem;
+  }
+
+  .ResultCard__Title {
+    font-size: 1.75rem;
+  }
+
+  .ResultCard__Object {
+    height: 40rem;
+  }
+
+  .ResultCard__Preview {
+    min-height: 40rem;
+  }
+}
+</style>

--- a/client/src/composables/__tests__/usePdfPreview.test.ts
+++ b/client/src/composables/__tests__/usePdfPreview.test.ts
@@ -1,0 +1,110 @@
+import "../../test-utils/setupConfig";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { defineComponent, h, ref, nextTick } from "vue";
+import { mount } from "@vue/test-utils";
+import { usePdfPreview } from "../usePdfPreview";
+
+const VALID_BASE64 = btoa("%PDF-1.4 fake pdf content");
+
+describe("usePdfPreview", () => {
+  let createObjectURLSpy: ReturnType<typeof vi.spyOn>;
+  let revokeObjectURLSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    createObjectURLSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:fake-url");
+    revokeObjectURLSpy = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a blob URL from a base64 string", async () => {
+    const source = ref(VALID_BASE64);
+    const TestComponent = defineComponent({
+      setup() {
+        const { blobUrl } = usePdfPreview(source);
+        return { blobUrl };
+      },
+      render() {
+        return h("div", this.blobUrl);
+      },
+    });
+
+    const wrapper = mount(TestComponent);
+    await nextTick();
+
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
+    expect(wrapper.vm.blobUrl).toBe("blob:fake-url");
+    wrapper.unmount();
+  });
+
+  it("revokes the previous URL when the source changes", async () => {
+    const source = ref(VALID_BASE64);
+    const TestComponent = defineComponent({
+      setup() {
+        const { blobUrl } = usePdfPreview(source);
+        return { blobUrl };
+      },
+      render() {
+        return h("div");
+      },
+    });
+
+    const wrapper = mount(TestComponent);
+    await nextTick();
+
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
+
+    source.value = btoa("%PDF-1.4 different content");
+    await nextTick();
+
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:fake-url");
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(2);
+    wrapper.unmount();
+  });
+
+  it("revokes the URL when the component is unmounted", async () => {
+    const source = ref(VALID_BASE64);
+    const TestComponent = defineComponent({
+      setup() {
+        const { blobUrl } = usePdfPreview(source);
+        return { blobUrl };
+      },
+      render() {
+        return h("div");
+      },
+    });
+
+    const wrapper = mount(TestComponent);
+    await nextTick();
+
+    wrapper.unmount();
+
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:fake-url");
+  });
+
+  it("does not create a URL when source is empty", async () => {
+    const source = ref("");
+    const TestComponent = defineComponent({
+      setup() {
+        const { blobUrl } = usePdfPreview(source);
+        return { blobUrl };
+      },
+      render() {
+        return h("div");
+      },
+    });
+
+    const wrapper = mount(TestComponent);
+    await nextTick();
+
+    expect(createObjectURLSpy).not.toHaveBeenCalled();
+    expect(wrapper.vm.blobUrl).toBe("");
+    wrapper.unmount();
+  });
+});

--- a/client/src/composables/usePdfPreview.ts
+++ b/client/src/composables/usePdfPreview.ts
@@ -1,0 +1,38 @@
+import { ref, watch, onScopeDispose, type Ref } from "vue";
+
+function base64ToBlob(base64: string, mimeType: string): Blob {
+  const byteCharacters = atob(base64);
+  const buffer = new ArrayBuffer(byteCharacters.length);
+  const byteArray = new Uint8Array(buffer);
+  for (let i = 0; i < byteCharacters.length; i++) {
+    byteArray[i] = byteCharacters.charCodeAt(i);
+  }
+  return new Blob([buffer], { type: mimeType });
+}
+
+export function usePdfPreview(source: Ref<string>) {
+  const blobUrl = ref<string>("");
+
+  const revoke = () => {
+    if (blobUrl.value) {
+      URL.revokeObjectURL(blobUrl.value);
+      blobUrl.value = "";
+    }
+  };
+
+  watch(
+    source,
+    (newBase64) => {
+      revoke();
+      if (newBase64) {
+        const blob = base64ToBlob(newBase64, "application/pdf");
+        blobUrl.value = URL.createObjectURL(blob);
+      }
+    },
+    { immediate: true },
+  );
+
+  onScopeDispose(revoke);
+
+  return { blobUrl };
+}

--- a/client/src/lib/conferenceServices.ts
+++ b/client/src/lib/conferenceServices.ts
@@ -8,6 +8,7 @@ import type {
   CurrentTranslations,
   SpreadableDLM,
   SupportedLocale,
+  PublishedResult,
 } from "../Types";
 import type { AxiosInstance } from "axios";
 
@@ -18,15 +19,19 @@ const conferenceApi = ref<AxiosInstance>(
 );
 
 const currentTranslationsData = ref<CurrentTranslations>(null);
+let interceptorAttached = false;
 
 export function useConferenceConnector(
   organisationSlug: string,
   electionSlug: string,
 ) {
-  conferenceApi.value.interceptors.response.use(
-    responseHandler,
-    responseErrorHandler,
-  );
+  if (!interceptorAttached) {
+    conferenceApi.value.interceptors.response.use(
+      responseHandler,
+      responseErrorHandler,
+    );
+    interceptorAttached = true;
+  }
 
   return {
     conferenceClient: {
@@ -64,6 +69,17 @@ export function useConferenceConnector(
         };
 
         return evsTranslations;
+      },
+      async getPublishedResults() {
+        return (await conferenceApi.value.get(
+          `/${organisationSlug}/${electionSlug}/published_results`,
+        )) as unknown as PublishedResult[];
+      },
+      async getResultsPublished() {
+        const response = await conferenceApi.value.get(
+          `/${organisationSlug}/${electionSlug}/results_published`,
+        );
+        return (response as any).resultsPublished as boolean;
       },
     },
   };

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -12,6 +12,7 @@ import MissingSlugView from "../views/MissingSlugView.vue";
 import BallotVerificationLanding from "../views/BallotVerificationLanding.vue";
 import LogsView from "../views/LogsView.vue";
 import HelpView from "../views/HelpView.vue";
+import ResultsView from "../views/ResultsView.vue";
 import BallotTrackingLanding from "../views/BallotTrackingLanding.vue";
 import ReceiptErrorView from "../views/ReceiptErrorView.vue";
 import useConfigStore from "@/stores/useConfigStore";
@@ -44,6 +45,27 @@ const verifyGuard = async (
   }
 
   if (configStore.electionStatus?.canadianChallenge) {
+    next({
+      name: "Welcome",
+      params: {
+        locale: to.params.locale,
+        organisationSlug: to.params.organisationSlug,
+        electionSlug: to.params.electionSlug,
+      },
+    });
+  } else {
+    next();
+  }
+};
+
+const resultsGuard = (
+  to: RouteLocationNormalized,
+  _from: RouteLocationNormalized,
+  next: NavigationGuardNext,
+) => {
+  const configStore = useConfigStore();
+
+  if (!configStore.resultsPublished) {
     next({
       name: "Welcome",
       params: {
@@ -119,6 +141,12 @@ const router = createRouter({
       name: "HelpView",
       path: "/:locale/:organisationSlug/:electionSlug/help",
       component: HelpView,
+    },
+    {
+      name: "ResultsView",
+      path: "/:locale/:organisationSlug/:electionSlug/results",
+      component: ResultsView,
+      beforeEnter: resultsGuard,
     },
   ],
 });

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -58,12 +58,25 @@ const verifyGuard = async (
   }
 };
 
-const resultsGuard = (
+const resultsGuard = async (
   to: RouteLocationNormalized,
   _from: RouteLocationNormalized,
   next: NavigationGuardNext,
 ) => {
   const configStore = useConfigStore();
+
+  if (!configStore.resultsPublishedLoaded) {
+    const organisationSlug = to.params.organisationSlug as string;
+    const electionSlug = to.params.electionSlug as string;
+    try {
+      const response = await axios.get(
+        `${config.conferenceUrl}/${organisationSlug}/${electionSlug}/results_published`,
+      );
+      configStore.setResultsPublished(response.data?.resultsPublished ?? false);
+    } catch (err) {
+      console.error("Failed to fetch results_published in route guard:", err);
+    }
+  }
 
   if (!configStore.resultsPublished) {
     next({

--- a/client/src/stores/useConfigStore.ts
+++ b/client/src/stores/useConfigStore.ts
@@ -16,6 +16,7 @@ export default defineStore("useConfigStore", () => {
   const bcTimeout = computed(() => election.value?.bcTimeout);
   const electionStatus = ref<BasicElectionStatus | null>(null);
   const electionTheme = ref<string>(null);
+  const resultsPublished = ref<boolean>(false);
   const pageRefreshIterator = ref<number>(0);
 
   const setBoardSlug = (newBoardSlug: string) => {
@@ -77,6 +78,10 @@ export default defineStore("useConfigStore", () => {
     electionTheme.value = newTheme;
   };
 
+  const setResultsPublished = (value: boolean) => {
+    resultsPublished.value = value;
+  };
+
   const pageReloaded = () => pageRefreshIterator.value++;
 
   const usesElectionCommittee = computed((): boolean => {
@@ -95,6 +100,8 @@ export default defineStore("useConfigStore", () => {
     setElectionStatus,
     electionTheme,
     setElectionTheme,
+    resultsPublished,
+    setResultsPublished,
     setBoardSlug,
     pageRefreshIterator,
     pageReloaded,

--- a/client/src/stores/useConfigStore.ts
+++ b/client/src/stores/useConfigStore.ts
@@ -17,6 +17,7 @@ export default defineStore("useConfigStore", () => {
   const electionStatus = ref<BasicElectionStatus | null>(null);
   const electionTheme = ref<string>(null);
   const resultsPublished = ref<boolean>(false);
+  const resultsPublishedLoaded = ref<boolean>(false);
   const pageRefreshIterator = ref<number>(0);
 
   const setBoardSlug = (newBoardSlug: string) => {
@@ -80,6 +81,7 @@ export default defineStore("useConfigStore", () => {
 
   const setResultsPublished = (value: boolean) => {
     resultsPublished.value = value;
+    resultsPublishedLoaded.value = true;
   };
 
   const pageReloaded = () => pageRefreshIterator.value++;
@@ -101,6 +103,7 @@ export default defineStore("useConfigStore", () => {
     electionTheme,
     setElectionTheme,
     resultsPublished,
+    resultsPublishedLoaded,
     setResultsPublished,
     setBoardSlug,
     pageRefreshIterator,

--- a/client/src/views/ResultsView.a11y.test.ts
+++ b/client/src/views/ResultsView.a11y.test.ts
@@ -1,0 +1,128 @@
+import "../test-utils/setupConfig";
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { axe } from "vitest-axe";
+import { toHaveNoViolations } from "vitest-axe/dist/matchers.js";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createI18n } from "vue-i18n";
+import { createPinia } from "pinia";
+import { createRouter, createMemoryHistory } from "vue-router";
+import { defineComponent, h } from "vue";
+import type { PublishedResult } from "@/Types";
+import { fallbackMessages } from "../assets/translations";
+
+expect.extend({ toHaveNoViolations });
+
+const getPublishedResultsMock = vi.fn();
+
+vi.mock("@/lib/conferenceServices", () => ({
+  useConferenceConnector: () => ({
+    conferenceClient: { getPublishedResults: getPublishedResultsMock },
+  }),
+}));
+
+const ResultsView = (await import("./ResultsView.vue")).default;
+
+const neededStrings = JSON.stringify(fallbackMessages.en);
+const messages = { en: JSON.parse(neededStrings) };
+const i18n = createI18n({ messages });
+
+vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:fake-url");
+vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+
+const mockResults: PublishedResult[] = [
+  {
+    votingRoundName: "Round A",
+    votingRoundClosingDate: "2025-01-10T00:00:00.000Z",
+    publishedAt: "2025-01-15T10:00:00.000Z",
+    pdf: btoa("%PDF-1.4 content A"),
+  },
+];
+
+function createTestRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        path: "/:locale/:organisationSlug/:electionSlug/results",
+        name: "ResultsView",
+        component: { template: "<div />" },
+      },
+    ],
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getPublishedResultsMock.mockResolvedValue(mockResults);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+test("ResultsView has no accessibility violations with results", async () => {
+  const router = createTestRouter();
+  await router.push("/en/org_slug/election_slug/results");
+  await router.isReady();
+
+  const Wrapper = defineComponent({
+    setup() {
+      return () => h("main", [h(ResultsView)]);
+    },
+  });
+
+  const wrapper = mount(Wrapper, {
+    global: { plugins: [i18n, createPinia(), router] },
+  });
+
+  await flushPromises();
+  const results = await axe(wrapper.element);
+  await expect(results).toHaveNoViolations();
+  wrapper.unmount();
+});
+
+test("ResultsView has no accessibility violations in empty state", async () => {
+  getPublishedResultsMock.mockResolvedValue([]);
+
+  const router = createTestRouter();
+  await router.push("/en/org_slug/election_slug/results");
+  await router.isReady();
+
+  const Wrapper = defineComponent({
+    setup() {
+      return () => h("main", [h(ResultsView)]);
+    },
+  });
+
+  const wrapper = mount(Wrapper, {
+    global: { plugins: [i18n, createPinia(), router] },
+  });
+
+  await flushPromises();
+  const results = await axe(wrapper.element);
+  await expect(results).toHaveNoViolations();
+  wrapper.unmount();
+});
+
+test("ResultsView has no accessibility violations in error state", async () => {
+  getPublishedResultsMock.mockRejectedValue(new Error("Network error"));
+
+  const router = createTestRouter();
+  await router.push("/en/org_slug/election_slug/results");
+  await router.isReady();
+
+  const Wrapper = defineComponent({
+    setup() {
+      return () => h("main", [h(ResultsView)]);
+    },
+  });
+
+  const wrapper = mount(Wrapper, {
+    global: { plugins: [i18n, createPinia(), router] },
+  });
+
+  await flushPromises();
+  const results = await axe(wrapper.element);
+  await expect(results).toHaveNoViolations();
+  wrapper.unmount();
+});

--- a/client/src/views/ResultsView.test.ts
+++ b/client/src/views/ResultsView.test.ts
@@ -1,0 +1,119 @@
+import "../test-utils/setupConfig";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createI18n } from "vue-i18n";
+import { createPinia, setActivePinia } from "pinia";
+import { createRouter, createMemoryHistory } from "vue-router";
+import type { PublishedResult } from "@/Types";
+import { fallbackMessages } from "../assets/translations";
+
+const getPublishedResultsMock = vi.fn();
+
+vi.mock("@/lib/conferenceServices", () => ({
+  useConferenceConnector: () => ({
+    conferenceClient: { getPublishedResults: getPublishedResultsMock },
+  }),
+}));
+
+const ResultsView = (await import("./ResultsView.vue")).default;
+
+const neededStrings = JSON.stringify(fallbackMessages.en);
+const messages = { en: JSON.parse(neededStrings) };
+const i18n = createI18n({ messages });
+
+vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:fake-url");
+vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+
+const mockResults: PublishedResult[] = [
+  {
+    votingRoundName: "Round B",
+    votingRoundClosingDate: "2025-03-15T00:00:00.000Z",
+    publishedAt: "2025-03-20T10:00:00.000Z",
+    pdf: btoa("%PDF-1.4 content B"),
+  },
+  {
+    votingRoundName: "Round A",
+    votingRoundClosingDate: "2025-01-10T00:00:00.000Z",
+    publishedAt: "2025-01-15T10:00:00.000Z",
+    pdf: btoa("%PDF-1.4 content A"),
+  },
+  {
+    votingRoundName: "Round C",
+    votingRoundClosingDate: "2025-06-01T00:00:00.000Z",
+    publishedAt: "2025-06-05T10:00:00.000Z",
+    pdf: btoa("%PDF-1.4 content C"),
+  },
+];
+
+function createTestRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        path: "/:locale/:organisationSlug/:electionSlug/results",
+        name: "ResultsView",
+        component: { template: "<div />" },
+      },
+    ],
+  });
+}
+
+async function mountResultsView() {
+  setActivePinia(createPinia());
+  const router = createTestRouter();
+  await router.push("/en/org_slug/election_slug/results");
+  await router.isReady();
+
+  const wrapper = mount(ResultsView, {
+    global: {
+      plugins: [i18n, createPinia(), router],
+    },
+  });
+
+  await flushPromises();
+  return wrapper;
+}
+
+describe("ResultsView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders results sorted by closing date ascending", async () => {
+    getPublishedResultsMock.mockResolvedValue(mockResults);
+
+    const wrapper = await mountResultsView();
+
+    const titles = wrapper.findAll("#result-card-title");
+    expect(titles).toHaveLength(3);
+    expect(titles[0].text()).toBe("Round A");
+    expect(titles[1].text()).toBe("Round B");
+    expect(titles[2].text()).toBe("Round C");
+    wrapper.unmount();
+  });
+
+  it("renders empty state when no results are published", async () => {
+    getPublishedResultsMock.mockResolvedValue([]);
+
+    const wrapper = await mountResultsView();
+
+    expect(wrapper.find("#results-empty").exists()).toBe(true);
+    expect(wrapper.find("#result-card-title").exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it("renders error state with retry button when fetch fails", async () => {
+    getPublishedResultsMock.mockRejectedValue(new Error("Network error"));
+
+    const wrapper = await mountResultsView();
+
+    expect(wrapper.find("#results-error").exists()).toBe(true);
+    expect(wrapper.find("#results-retry").exists()).toBe(true);
+    expect(wrapper.find("#result-card-title").exists()).toBe(false);
+    wrapper.unmount();
+  });
+});

--- a/client/src/views/ResultsView.test.ts
+++ b/client/src/views/ResultsView.test.ts
@@ -88,7 +88,7 @@ describe("ResultsView", () => {
 
     const wrapper = await mountResultsView();
 
-    const titles = wrapper.findAll("#result-card-title");
+    const titles = wrapper.findAll('[data-testid="result-card-title"]');
     expect(titles).toHaveLength(3);
     expect(titles[0].text()).toBe("Round A");
     expect(titles[1].text()).toBe("Round B");
@@ -102,7 +102,7 @@ describe("ResultsView", () => {
     const wrapper = await mountResultsView();
 
     expect(wrapper.find("#results-empty").exists()).toBe(true);
-    expect(wrapper.find("#result-card-title").exists()).toBe(false);
+    expect(wrapper.find('[data-testid="result-card-title"]').exists()).toBe(false);
     wrapper.unmount();
   });
 
@@ -113,7 +113,7 @@ describe("ResultsView", () => {
 
     expect(wrapper.find("#results-error").exists()).toBe(true);
     expect(wrapper.find("#results-retry").exists()).toBe(true);
-    expect(wrapper.find("#result-card-title").exists()).toBe(false);
+    expect(wrapper.find('[data-testid="result-card-title"]').exists()).toBe(false);
     wrapper.unmount();
   });
 });

--- a/client/src/views/ResultsView.test.ts
+++ b/client/src/views/ResultsView.test.ts
@@ -102,7 +102,9 @@ describe("ResultsView", () => {
     const wrapper = await mountResultsView();
 
     expect(wrapper.find("#results-empty").exists()).toBe(true);
-    expect(wrapper.find('[data-testid="result-card-title"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="result-card-title"]').exists()).toBe(
+      false,
+    );
     wrapper.unmount();
   });
 
@@ -113,7 +115,9 @@ describe("ResultsView", () => {
 
     expect(wrapper.find("#results-error").exists()).toBe(true);
     expect(wrapper.find("#results-retry").exists()).toBe(true);
-    expect(wrapper.find('[data-testid="result-card-title"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="result-card-title"]').exists()).toBe(
+      false,
+    );
     wrapper.unmount();
   });
 });

--- a/client/src/views/ResultsView.vue
+++ b/client/src/views/ResultsView.vue
@@ -1,0 +1,213 @@
+<script setup lang="ts">
+import { onMounted, ref, computed } from "vue";
+import { useRoute } from "vue-router";
+import ContentLayout from "@/components/ContentLayout.vue";
+import MainIcon from "@/components/MainIcon.vue";
+import ResultCard from "@/components/ResultCard.vue";
+import useConfigStore from "@/stores/useConfigStore";
+import { useConferenceConnector } from "@/lib/conferenceServices";
+import type { PublishedResult } from "@/Types";
+
+const route = useRoute();
+const configStore = useConfigStore();
+
+const organisationSlug = route.params.organisationSlug.toString();
+const electionSlug = route.params.electionSlug.toString();
+const { conferenceClient } = useConferenceConnector(
+  organisationSlug,
+  electionSlug,
+);
+
+const results = ref<PublishedResult[]>([]);
+const hasError = ref<boolean>(false);
+const isLoaded = ref<boolean>(false);
+
+const sortedResults = computed(() => {
+  return [...results.value].sort((a, b) => {
+    const dateA = a.votingRoundClosingDate || a.publishedAt;
+    const dateB = b.votingRoundClosingDate || b.publishedAt;
+    return new Date(dateA).getTime() - new Date(dateB).getTime();
+  });
+});
+
+const loadResults = async () => {
+  hasError.value = false;
+  isLoaded.value = false;
+  try {
+    results.value = await conferenceClient.getPublishedResults();
+  } catch (err) {
+    console.error(err);
+    hasError.value = true;
+  } finally {
+    isLoaded.value = true;
+  }
+};
+
+onMounted(loadResults);
+</script>
+
+<template>
+  <ContentLayout
+    id="results-view"
+    :help-title="$t('views.results.help.title')"
+    :help-title-strong="$t('views.results.help.title_strong')"
+    :logo="configStore.electionStatus?.theme?.logo"
+  >
+    <template v-slot:action>
+      <MainIcon icon="square-poll-vertical" id="results-main-icon" />
+      <h1 class="ResultsView__Title" id="results-title">
+        {{ $t("views.results.title") }}
+      </h1>
+      <p class="ResultsView__Description" id="results-description">
+        {{ $t("views.results.description") }}
+      </p>
+
+      <div
+        v-if="isLoaded && !hasError"
+        class="ResultsView__List"
+        id="results-list"
+      >
+        <ResultCard
+          v-for="result in sortedResults"
+          :key="result.votingRoundName"
+          :result="result"
+        />
+
+        <p
+          v-if="sortedResults.length === 0"
+          class="ResultsView__Empty"
+          id="results-empty"
+        >
+          {{ $t("views.results.empty_state") }}
+        </p>
+      </div>
+
+      <div
+        v-if="isLoaded && hasError"
+        class="ResultsView__Error"
+        id="results-error"
+      >
+        <p class="ResultsView__Error_Text" id="results-error-text">
+          {{ $t("views.results.error_state") }}
+        </p>
+        <button
+          class="btn btn-theme rounded-3 ResultsView__Retry"
+          type="button"
+          @click="loadResults"
+          id="results-retry"
+        >
+          {{ $t("views.results.retry") }}
+        </button>
+      </div>
+    </template>
+    <template v-slot:help>
+      <h3
+        class="ResultsView__Help_Title text-contrast"
+        id="results-help-p1-question"
+      >
+        {{ $t("views.results.help.p1.question") }}
+      </h3>
+      <p
+        class="ResultsView__Help_Description text-contrast"
+        id="results-help-p1-answer"
+      >
+        {{ $t("views.results.help.p1.answer") }}
+      </p>
+    </template>
+  </ContentLayout>
+</template>
+
+<style scoped>
+.ResultsView__Title {
+  font-size: 2.5rem;
+  font-weight: 600;
+  color: var(--bs-gray-800);
+  margin: 0.5rem 0 1rem 0;
+  text-align: center;
+}
+
+.ResultsView__Description {
+  color: var(--bs-gray-700);
+  margin: 0 0 1.5rem 0;
+  text-align: center;
+}
+
+.ResultsView__List {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.ResultsView__Empty {
+  color: var(--bs-gray-600);
+  text-align: center;
+  padding: 3rem 1rem;
+  font-size: 1.125rem;
+}
+
+.ResultsView__Error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 3rem 1rem;
+}
+
+.ResultsView__Error_Text {
+  color: var(--bs-danger);
+  text-align: center;
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+.ResultsView__Retry {
+  padding: 0.5rem 1.5rem;
+}
+
+.ResultsView__Help_Title {
+  text-align: center;
+  font-size: 1.6rem;
+  margin: 0 0 1.5rem 0;
+}
+
+.ResultsView__Help_Description {
+  margin: 0 0 1.5rem 0;
+}
+
+@media only screen and (min-width: 48rem) {
+  .ResultsView__Title {
+    margin: 0 0 1.5rem 0;
+  }
+}
+
+@media only screen and (min-width: 80rem) {
+  .ResultsView__Title {
+    font-size: 3.5rem;
+  }
+
+  .ResultsView__Description {
+    text-align: left;
+    align-self: flex-start;
+  }
+
+  .ResultsView__Help_Title {
+    font-size: 1.25rem;
+    margin-bottom: 0.5rem;
+  }
+}
+
+@media only screen and (min-width: 120rem) {
+  .ResultsView__Title {
+    font-size: 3.5rem;
+  }
+
+  .ResultsView__Help_Title {
+    font-size: 1.8rem;
+  }
+
+  .ResultsView__Help_Description {
+    font-size: 1.2rem;
+  }
+}
+</style>

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1337,12 +1337,19 @@ alien-signals@^3.2.0:
   resolved "https://registry.yarnpkg.com/alien-signals/-/alien-signals-3.2.1.tgz#eb66256949bce90b7d30d055e2752e62d6930c7c"
   integrity sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==
 
+ansi-escapes@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.3.0.tgz#5395bb74b2150a4a1d6e3c2565f4aeca78d28627"
+  integrity sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==
+  dependencies:
+    environment "^1.0.0"
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-regex@^6.0.1:
+ansi-regex@^6.0.1, ansi-regex@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
   integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
@@ -1354,7 +1361,7 @@ ansi-styles@^4.0.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^6.1.0:
+ansi-styles@^6.0.0, ansi-styles@^6.1.0, ansi-styles@^6.2.1:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
@@ -1511,7 +1518,7 @@ chai@^6.2.2:
   resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
   integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
 
-chalk@^5.0.1:
+chalk@^5.0.1, chalk@^5.4.1:
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
   integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
@@ -1522,6 +1529,21 @@ chokidar@^5.0.0:
   integrity sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==
   dependencies:
     readdirp "^5.0.0"
+
+cli-cursor@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-5.0.0.tgz#24a4831ecf5a6b01ddeb32fb71a4b2088b0dce38"
+  integrity sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==
+  dependencies:
+    restore-cursor "^5.0.0"
+
+cli-truncate@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-4.0.0.tgz#6cc28a2924fee9e25ce91e973db56c7066e6172a"
+  integrity sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==
+  dependencies:
+    slice-ansi "^5.0.0"
+    string-width "^7.0.0"
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -1535,6 +1557,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+colorette@^2.0.20:
+  version "2.0.20"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
+  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -1546,6 +1573,11 @@ commander@^10.0.0:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
+commander@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-13.1.0.tgz#776167db68c78f38dcce1f9b8d7b8b9a488abf46"
+  integrity sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==
 
 confbox@^0.1.8:
   version "0.1.8"
@@ -1577,7 +1609,7 @@ copy-anything@^4:
   dependencies:
     is-what "^5.2.0"
 
-cross-spawn@^7.0.6:
+cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -1700,6 +1732,11 @@ editorconfig@^1.0.4:
     minimatch "9.0.1"
     semver "^7.5.3"
 
+emoji-regex@^10.3.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.6.0.tgz#bf3d6e8f7f8fd22a65d9703475bc0147357a6b0d"
+  integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -1719,6 +1756,11 @@ entities@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-7.0.1.tgz#26e8a88889db63417dcb9a1e79a3f1bc92b5976b"
   integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
+
+environment@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/environment/-/environment-1.1.0.tgz#8e86c66b180f363c7ab311787e0259665f45a9f1"
+  integrity sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==
 
 es-define-property@^1.0.1:
   version "1.0.1"
@@ -1918,6 +1960,26 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eventemitter3@^5.0.1:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.4.tgz#a86d66170433712dde814707ac52b5271ceb1feb"
+  integrity sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==
+
+execa@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-8.0.1.tgz#51f6a5943b580f963c3ca9c6321796db8cc39b8c"
+  integrity sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^8.0.1"
+    human-signals "^5.0.0"
+    is-stream "^3.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^5.1.0"
+    onetime "^6.0.0"
+    signal-exit "^4.1.0"
+    strip-final-newline "^3.0.0"
+
 expect-type@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
@@ -2062,6 +2124,11 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
+get-east-asian-width@^1.0.0, get-east-asian-width@^1.3.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz#216900f91df11a8b2c198c3e1d93d6c035a776b9"
+  integrity sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==
+
 get-intrinsic@^1.2.6:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
@@ -2085,6 +2152,11 @@ get-proto@^1.0.1:
   dependencies:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
+
+get-stream@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-8.0.1.tgz#def9dfd71742cd7754a7761ed43749a27d02eca2"
+  integrity sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==
 
 glob-parent@^5.1.2:
   version "5.1.2"
@@ -2182,6 +2254,16 @@ https-proxy-agent@^7.0.6:
     agent-base "^7.1.2"
     debug "4"
 
+human-signals@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
+  integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
+
+husky@^9.1.7:
+  version "9.1.7"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
+  integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
+
 ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
@@ -2227,6 +2309,18 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
+is-fullwidth-code-point@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz#fae3167c729e7463f8461ce512b080a49268aa88"
+  integrity sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==
+
+is-fullwidth-code-point@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz#046b2a6d4f6b156b2233d3207d4b5a9783999b98"
+  integrity sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==
+  dependencies:
+    get-east-asian-width "^1.3.1"
+
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
@@ -2243,6 +2337,11 @@ is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
+is-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
+  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
 
 is-what@^5.2.0:
   version "5.5.0"
@@ -2430,6 +2529,39 @@ lightningcss@^1.32.0:
     lightningcss-win32-arm64-msvc "1.32.0"
     lightningcss-win32-x64-msvc "1.32.0"
 
+lilconfig@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
+  integrity sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==
+
+lint-staged@^15.5.2:
+  version "15.5.2"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-15.5.2.tgz#beff028fd0681f7db26ffbb67050a21ed4d059a3"
+  integrity sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==
+  dependencies:
+    chalk "^5.4.1"
+    commander "^13.1.0"
+    debug "^4.4.0"
+    execa "^8.0.1"
+    lilconfig "^3.1.3"
+    listr2 "^8.2.5"
+    micromatch "^4.0.8"
+    pidtree "^0.6.0"
+    string-argv "^0.3.2"
+    yaml "^2.7.0"
+
+listr2@^8.2.5:
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-8.3.3.tgz#815fc8f738260ff220981bf9e866b3e11e8121bf"
+  integrity sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==
+  dependencies:
+    cli-truncate "^4.0.0"
+    colorette "^2.0.20"
+    eventemitter3 "^5.0.1"
+    log-update "^6.1.0"
+    rfdc "^1.4.1"
+    wrap-ansi "^9.0.0"
+
 local-pkg@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-1.1.2.tgz#c03d208787126445303f8161619dc701afa4abb5"
@@ -2455,6 +2587,17 @@ lodash@^4.17.21:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
+
+log-update@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-6.1.0.tgz#1a04ff38166f94647ae1af562f4bd6a15b1b7cd4"
+  integrity sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==
+  dependencies:
+    ansi-escapes "^7.0.0"
+    cli-cursor "^5.0.0"
+    slice-ansi "^7.1.0"
+    strip-ansi "^7.1.0"
+    wrap-ansi "^9.0.0"
 
 lru-cache@^10.2.0:
   version "10.4.3"
@@ -2490,6 +2633,11 @@ mdn-data@2.12.2:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.12.2.tgz#9ae6c41a9e65adf61318b32bff7b64fbfb13f8cf"
   integrity sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==
 
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
 merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -2514,6 +2662,16 @@ mime-types@^2.1.12:
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
+
+mimic-fn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
+  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
+
+mimic-function@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
+  integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
 
 min-indent@^1.0.0:
   version "1.0.1"
@@ -2635,6 +2793,13 @@ nopt@^7.2.1:
   dependencies:
     abbrev "^2.0.0"
 
+npm-run-path@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.3.0.tgz#e23353d0ebb9317f174e93417e4a4d82d0249e9f"
+  integrity sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==
+  dependencies:
+    path-key "^4.0.0"
+
 nth-check@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
@@ -2646,6 +2811,20 @@ obug@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.1.tgz#2cba74ff241beb77d63055ddf4cd1e9f90b538be"
   integrity sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==
+
+onetime@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
+  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
+  dependencies:
+    mimic-fn "^4.0.0"
+
+onetime@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-7.0.0.tgz#9f16c92d8c9ef5120e3acd9dd9957cceecc1ab60"
+  integrity sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==
+  dependencies:
+    mimic-function "^5.0.0"
 
 optionator@^0.9.3:
   version "0.9.4"
@@ -2705,6 +2884,11 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
+path-key@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
+  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
+
 path-scurry@^1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
@@ -2757,6 +2941,11 @@ picomatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
+pidtree@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.1.tgz#3d03fae6183cc07091947dcc1087ce567cd3bcd3"
+  integrity sha512-e0F9AOF1JMrCfBsyJOwU9lNvQ0WtXTq0j/4jk0BQ5JSI9VAybPXmDpPRw/2FQ3e5d3ZFN1mLh7jW99m/jjaptw==
 
 pinia@^3.0.4:
   version "3.0.4"
@@ -2892,6 +3081,14 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
+restore-cursor@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-5.1.0.tgz#0766d95699efacb14150993f55baf0953ea1ebe7"
+  integrity sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==
+  dependencies:
+    onetime "^7.0.0"
+    signal-exit "^4.1.0"
+
 reusify@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
@@ -2983,7 +3180,7 @@ siginfo@^2.0.0:
   resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
 
-signal-exit@^4.0.1:
+signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
@@ -3003,6 +3200,22 @@ sjcl-with-all@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/sjcl-with-all/-/sjcl-with-all-1.0.8.tgz#a5814708065d58605c85005edd5c1be274ef9313"
   integrity sha512-bPO15hskif7tpu/LpAQgnJgZESsYOIHrNSxgZ7nM4rbF9rOtt6rm4ECQaFvY5/JLay5lhi2YIaLcD4xJJgY29w==
+
+slice-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-5.0.0.tgz#b73063c57aa96f9cd881654b15294d95d285c42a"
+  integrity sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==
+  dependencies:
+    ansi-styles "^6.0.0"
+    is-fullwidth-code-point "^4.0.0"
+
+slice-ansi@^7.1.0:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-7.1.2.tgz#adf7be70aa6d72162d907cd0e6d5c11f507b5403"
+  integrity sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==
+  dependencies:
+    ansi-styles "^6.2.1"
+    is-fullwidth-code-point "^5.0.0"
 
 "source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.1, source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
@@ -3024,16 +3237,12 @@ std-env@^4.0.0-rc.1:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.1.0.tgz#45899abc590d86d682e87f0acd1033a75084cd3f"
   integrity sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
+string-argv@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
+  integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3051,14 +3260,16 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+string-width@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
+  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
   dependencies:
-    ansi-regex "^5.0.1"
+    emoji-regex "^10.3.0"
+    get-east-asian-width "^1.0.0"
+    strip-ansi "^7.1.0"
 
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3071,6 +3282,18 @@ strip-ansi@^7.0.1:
   integrity sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==
   dependencies:
     ansi-regex "^6.0.1"
+
+strip-ansi@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
+
+strip-final-newline@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
+  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
 strip-indent@^3.0.0:
   version "3.0.0"
@@ -3533,6 +3756,15 @@ wrap-ansi@^8.1.0:
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
 
+wrap-ansi@^9.0.0:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz#956832dea9494306e6d209eb871643bb873d7c98"
+  integrity sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==
+  dependencies:
+    ansi-styles "^6.2.1"
+    string-width "^7.0.0"
+    strip-ansi "^7.1.0"
+
 xml-js@^1.6.11:
   version "1.6.11"
   resolved "https://registry.yarnpkg.com/xml-js/-/xml-js-1.6.11.tgz#927d2f6947f7f1c19a316dd8eea3614e8b18f8e9"
@@ -3555,7 +3787,7 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-yaml@^2.9.0:
+yaml@^2.7.0, yaml@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
   integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==


### PR DESCRIPTION
Conference PR https://github.com/aion-dk/conference/pull/3115

## Summary

This PR adds a new results view for displaying published election results with PDF previews, introduces comprehensive accessibility testing and improvements, and adds dynamic election branding (document title and favicon). It also includes layout refactoring, custom footer HTML support, dependency upgrades, and infrastructure fixes.

## Changes

- **Results View**: New `ResultsView.vue` and `ResultCard.vue` components displaying published election results sorted by date, with inline PDF preview via blob URL and download links. New `/results` route guarded by `resultsGuard` (redirects to Welcome if results not published). Results link conditionally shown in header when `resultsPublished` is true.
- **Election Branding**: New `useElectionBranding` composable for dynamic document title (from `votingPortal.tabName` or election title) and favicon (from `votingPortal.faviconUrl`), replacing the old `setTitle` function in `App.vue`.
- **PDF Preview**: New `usePdfPreview` composable converting base64-encoded PDFs to object URLs with automatic cleanup via `onScopeDispose`.
- **Accessibility**: Added `eslint-plugin-vuejs-accessibility` with recommended ruleset, `vitest-axe` for component-level a11y tests, and a Playwright accessibility spec using `@axe-core/playwright`. Added ID attributes to elements across all views and components for test targeting. Fixed heading hierarchy (e.g., `h3` → `h2` in Welcome cards). Added `tabindex="0"` to help content aside for Safari keyboard scrolling. Added `rel="noopener noreferrer"` to external links.
- **Layout Refactor**: Replaced fixed-height calculations (`calc(100dvh - 70px)`) with flex-based layout using `min-height`. Header changed from `position: fixed` to `position: sticky`. Removed `overflow: hidden` on body. ContentLayout switched from fixed positioning to flex column.
- **Custom Footer**: Added `dompurify` dependency for sanitizing custom footer HTML with support for `rel` attributes on external links. Extended `Footer.vue` with custom HTML rendering and flexible height.
- **Canadian Challenge Support**: Conditional rendering of ballot tester card and verification link when `canadianChallenge` flag is set on election status.
- **Conference Services**: Added `getPublishedResults()` and `getResultsPublished()` API methods. Fixed interceptor duplication with `interceptorAttached` guard. Fixed `getStylingData()` return type.
- **i18n**: Safe URL parsing in `getLocaleFromUrl()` with try/catch for SSR/test environments. Added translation keys for results view.
- **Types**: New `PublishedResult` and `CustomCosmetics` interfaces. Extended `VotingPortal` with `tabName` and `faviconUrl`, `BasicElectionStatus` with `votingPortal` and `canadianChallenge`.
- **Dependencies**: Upgraded `@assemblyvoting/electa-ui` to `5.7.2-ontario`, Vite to 8.x, added `dompurify`, `vitest-axe`, `eslint-plugin-vuejs-accessibility`, `globals`. Pinned `undici` to `^7.28.0`.
- **Infrastructure**: Nginx PID moved to `/tmp/nginx.pid`, Dockerfile Playwright image reverted to v1.60.0 with `corepack enable`, Firefox and Mobile Safari Playwright projects temporarily disabled.
- **Documentation**: Added `doc/translation-keys.md` with translation keys report.

## Files Changed

| File | Change |
|------|--------|
| `client/src/views/ResultsView.vue` | New results view with sorted result cards and error/retry handling |
| `client/src/components/ResultCard.vue` | New component for individual result display with PDF preview |
| `client/src/composables/useElectionBranding.ts` | New composable for dynamic title/favicon |
| `client/src/composables/usePdfPreview.ts` | New composable for base64-to-blob PDF preview |
| `client/src/components/PageTitle.vue` | New component for page title display |
| `client/src/test-utils/a11y.ts` | New test utility for mounting components with a11y checks |
| `client/src/test-utils/setupConfig.ts` | New test config setup helper |
| `client/src/router/index.ts` | Added results route, verify/results guards |
| `client/src/stores/useConfigStore.ts` | Added `resultsPublished` state |
| `client/src/lib/conferenceServices.ts` | Added results API methods, interceptor dedup |
| `client/src/lib/i18n.ts` | Safe URL locale parsing |
| `client/src/Types.ts` | New interfaces and type extensions |
| `client/src/App.vue` | Integrated branding composable, results published check, layout fixes |
| `client/src/components/Header.vue` | Sticky positioning, logo display, results link, a11y IDs |
| `client/src/components/ContentLayout.vue` | Flex layout, tabindex on help aside, a11y IDs |
| `client/src/components/Footer.vue` | Custom HTML support with DOMPurify sanitization |
| `client/src/components/DropDown.vue` | Added id prop, wrapper container |
| `client/src/components/Error.vue` | Dynamic ID generation from errorPath |
| `client/src/views/Welcome.vue` | Simplified layout, Canadian challenge conditionals, heading fixes |
| `client/e2e/accessibility.spec.ts` | New Playwright accessibility test spec |
| `client/e2e/results.spec.ts` | New Playwright results view test spec |
| `client/eslint.config.js` | Added vuejs-accessibility plugin and rules |
| `client/package.json` | Dependency updates and additions |
| `client/Dockerfile` | Playwright image version, corepack, nginx permissions |
| `client/nginx.conf` | PID file location |
| `doc/translation-keys.md` | Translation keys report |

## Notes

- **Firefox and Mobile Safari** Playwright projects are temporarily commented out — should be re-enabled before merge or in a follow-up.
- `@assemblyvoting/electa-ui` is pinned to `5.7.2-ontario` (pre-release tag) rather than a stable version.
- `@assemblyvoting/js-client` was downgraded from `^6.5.0` to `^6.3.0` — verify this is intentional.
- The `VotingPortal` and `BasicElectionStatus` type extensions use TypeScript module augmentation on `@assemblyvoting/types` — ensure upstream types are aligned.